### PR TITLE
Split out `battery_system` sensors (fixes #28)

### DIFF
--- a/.github/workflows/hassfest.yaml
+++ b/.github/workflows/hassfest.yaml
@@ -10,5 +10,5 @@ jobs:
   validate:
     runs-on: "ubuntu-latest"
     steps:
-      - uses: "actions/checkout@v2"
+      - uses: "actions/checkout@v3"
       - uses: home-assistant/actions/hassfest@master

--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,16 @@
+### 230225
+
+- split out 'battery_system' information (`ppv`, `ipv`, `upv`)into own sensors (thanks @TobyRh)
+
+  WARNING: This is possibly a breaking change! If your setup doesn't provide values for `ppv`, `ipv`
+  and `upv` under the inverter settings, those values are lost and can now be found under new names:
+  | before | after |
+  |---|---|
+  | `inverter_ipv` | `battery_system_ipv` |
+  | `inverter_ppv` | `battery_system_ppv` |
+  | `inverter_upv` | `battery_system_upv` |
+
+  You can check your system's settings using [this gist](https://gist.github.com/RustyDust/2dfdd9e9d0f3b5476b5e466203123f6f)
+- make GitHub actions work again
+  - fix ordering of keys in manifest.json
+  - update to actions@v3

--- a/custom_components/sonnenbatterie/manifest.json
+++ b/custom_components/sonnenbatterie/manifest.json
@@ -1,11 +1,11 @@
 {
     "domain": "sonnenbatterie",
     "name": "Sonnenbatterie",
-    "documentation": "https://github.com/weltmeyer/ha_sonnenbatterie",
-    "dependencies": [],
     "codeowners": ["@weltmeyer"],
-    "requirements": ["requests","sonnenbatterie>=0.1.1"],
     "config_flow": true,
-    "version": "2020.06.07",
-    "iot_class": "local_polling"
+    "dependencies": [],
+    "documentation": "https://github.com/weltmeyer/ha_sonnenbatterie",
+    "iot_class": "local_polling",
+    "requirements": ["requests","sonnenbatterie>=0.1.1"],
+    "version": "2020.06.07"
 }

--- a/custom_components/sonnenbatterie/sensor.py
+++ b/custom_components/sonnenbatterie/sensor.py
@@ -274,140 +274,144 @@ class SonnenBatterieMonitor:
                     SensorDeviceClass.FREQUENCY
                 )
 
-            # except:
+        # battery_system values
+        if not "battery_system_ipv" in self.disabledSensors:
+            if 'ipv' in battery_system['grid_information']:
+                self._AddOrUpdateEntity(
+                    allSensorsPrefix+"battery_system_ipv",
+                    "Battery System IPV - Current",
+                    battery_system['grid_information']['ipv'],
+                    "A",
+                    SensorDeviceClass.CURRENT
+                )
+            else:
+                self.disabledSensors.append("battery_system_ipv")
+                LOGGER.warning("No 'ipv' in battery_system -> sensor disabled")
+                if self.debug:
+                    self.SendAllDataToLog()
 
-        if not "inverter_ppv" in self.disabledSensors:
-            val_found = True
+        if not "battery_system_ppv" in self.disabledSensors:
             if 'ppv' in battery_system['grid_information']:
-                val=battery_system['grid_information']['ppv']
-            elif 'ppv' in inverter['status']:
-                val=inverter['status']['ppv']
+                self._AddOrUpdateEntity(
+                    allSensorsPrefix+"battery_system_ppv",
+                    "Battery System PPV - Power",
+                    battery_system['grid_information']['ppv'],
+                    "W",
+                    SensorDeviceClass.POWER
+                )
+            else:
+                self.disabledSensors.append("battery_system_ppv")
+                LOGGER.warning("No 'ppv' in battery_system -> sensor disabled")
+                if self.debug:
+                    self.SendAllDataToLog()
+
+        if not "battery_system_upv" in self.disabledSensors:
+            if 'upv' in battery_system['grid_information']:
+                self._AddOrUpdateEntity(
+                    allSensorsPrefix+"battery_system_upv",
+                    "Battery System UPV - Voltage UPV",
+                    battery_system['grid_information']['upv'],
+                    "V",
+                    SensorDeviceClass.VOLTAGE
+                )
+            else:
+                self.disabledSensors.append("battery_system_upv")
+                LOGGER.warning("No 'upv' in battery_system -> sensor disabled")
+                if self.debug:
+                    self.SendAllDataToLog()
+
+        # inverter values
+        if not "inverter_ppv" in self.disabledSensors:
+            if 'ppv' in inverter['status']:
+                self._AddOrUpdateEntity(
+                    allSensorsPrefix+"inverter_ppv",
+                    "Inverter PPV1 - Hybrid Solar Power PPV1",
+                    inverter['status']['ppv'],
+                    "W",
+                    SensorDeviceClass.POWER
+                )
             else:
                 self.disabledSensors.append("inverter_ppv")
-                val_found = False
                 LOGGER.warning("No 'ppv' in inverter -> sensor disabled")
                 if self.debug:
                     self.SendAllDataToLog()
 
-            if val_found:
-                self._AddOrUpdateEntity(
-                    allSensorsPrefix+"inverter_ppv",
-                    "Inverter PPV1 - Hybrid Solar Power PPV1",
-                    val,
-                    "W",
-                    SensorDeviceClass.POWER#"power"
-                )
-
         if not "inverter_ppv2" in self.disabledSensors:
             val_found = True
-            if 'ppv2' in battery_system['grid_information']:
-                val=battery_system['grid_information']['ppv2']
-            elif 'ppv2' in inverter['status']:
-                val=inverter['status']['ppv2']
+            if 'ppv2' in inverter['status']:
+                self._AddOrUpdateEntity(
+                    allSensorsPrefix+"inverter_ppv2",
+                    "Inverter PPV2 - Hybrid Solar Power PPV2",
+                    inverter['status']['ppv2'],
+                    "W",
+                    SensorDeviceClass.POWER
+                )
             else:
                 self.disabledSensors.append("inverter_ppv2")
-                val_found = False
                 LOGGER.warning("No 'ppv2' in inverter -> sensor disabled")
                 if self.debug:
                     self.SendAllDataToLog()
 
-            if val_found:
-                self._AddOrUpdateEntity(
-                    allSensorsPrefix+"inverter_ppv2",
-                    "Inverter PPV2 - Hybrid Solar Power PPV2",
-                    val,
-                    "W",
-                    SensorDeviceClass.POWER
-                )
-
         if not "inverter_ipv" in self.disabledSensors:
-            val_found = True
-            if 'ipv' in battery_system['grid_information']:
-                val = battery_system['grid_information']['ipv']
-            elif 'ipv' in inverter['status']:
-                val=inverter['status']['ipv']
+            if 'ipv' in inverter['status']:
+                self._AddOrUpdateEntity(
+                    allSensorsPrefix+"inverter_ipv",
+                    "Inverter IPV - Current IPV",
+                    inverter['status']['ipv'],
+                    "A",
+                    SensorDeviceClass.CURRENT
+                )
             else:
                 self.disabledSensors.append("inverter_ipv")
-                val_found = False
                 LOGGER.warning("No 'ipv' in inverter -> sensor disabled")
                 if self.debug:
                     self.SendAllDataToLog()
 
-            if val_found:
+
+        if not "inverter_ipv2" in self.disabledSensors:
+            if 'ipv2' in inverter['status']:
                 self._AddOrUpdateEntity(
-                    allSensorsPrefix+"inverter_ipv",
-                    "Inverter IPV - Current IPV",
-                    val,
+                    allSensorsPrefix+"inverter_ipv2",
+                    "Inverter IPV - Current IPV2",
+                    inverter['status']['ipv2'],
                     "A",
                     SensorDeviceClass.CURRENT
                 )
-
-
-        if not "inverter_ipv2" in self.disabledSensors:
-            val_found = True
-            if 'ipv2' in battery_system['grid_information']:
-                val = battery_system['grid_information']['ipv2']
-            elif 'ipv2' in inverter['status']:
-                val=inverter['status']['ipv2']
             else:
                 self.disabledSensors.append("inverter_ipv2")
-                val_found = False
                 LOGGER.warning("No 'ipv2' in inverter -> sensor disabled")
                 if self.debug:
                     self.SendAllDataToLog()
 
-            if val_found:
-                self._AddOrUpdateEntity(
-                    allSensorsPrefix+"inverter_ipv2",
-                    "Inverter IPV - Current IPV2",
-                    val,
-                    "A",
-                    SensorDeviceClass.CURRENT
-                )
-
         if not "inverter_upv" in self.disabledSensors:
-            val_found = True
-            if 'upv' in battery_system['grid_information']:
-                val = battery_system['grid_information']['upv']
-            elif 'upv' in inverter['status']:
-                val=inverter['status']['upv']
+            if 'upv' in inverter['status']:
+                self._AddOrUpdateEntity(
+                    allSensorsPrefix+"inverter_upv",
+                    "Inverter IPV - Voltage UPV",
+                    inverter['status']['upv'],
+                    "V",
+                    SensorDeviceClass.VOLTAGE
+                )
             else:
                 self.disabledSensors.append("inverter_upv")
-                val_found = False
                 LOGGER.warning("No 'upv' in inverter -> sensor disabled")
                 if self.debug:
                     self.SendAllDataToLog()
 
-            if val_found:
-                self._AddOrUpdateEntity(
-                    allSensorsPrefix+"inverter_upv",
-                    "Inverter IPV - Voltage UPV",
-                    val,
-                    "V",
-                    SensorDeviceClass.VOLTAGE
-                )
-
         if not "inverter_upv2" in self.disabledSensors:
-            val_found = True
-            if 'upv2' in battery_system['grid_information']:
-                val = battery_system['grid_information']['upv2']
-            elif 'upv2' in inverter['status']:
-                val=inverter['status']['upv2']
-            else:
-                self.disabledSensors.append("inverter_upv2")
-                val_found = False
-                LOGGER.warning("No 'upv2' in inverter -> sensor disabled")
-                if self.debug:
-                    self.SendAllDataToLog()
-
-            if val_found:
+            if 'upv2' in inverter['status']:
                 self._AddOrUpdateEntity(
                     allSensorsPrefix+"inverter_upv2",
                     "Inverter IPV - Voltage UPV2",
-                    val,
+                    inverter['status']['upv2'],
                     "V",
                     SensorDeviceClass.VOLTAGE
                 )
+            else:
+                self.disabledSensors.append("inverter_upv2")
+                LOGGER.warning("No 'upv2' in inverter -> sensor disabled")
+                if self.debug:
+                    self.SendAllDataToLog()
 
         """whatever comes next"""
         val_modulecount=int(battery_system['modules'])
@@ -519,7 +523,7 @@ class SonnenBatterieMonitor:
             self._AddOrUpdateEntity(sensorname,friendlyname,val,unitname,SensorDeviceClass.POWER)
 
         """" Battery Raw Capacity Calc """
-        measurements_status=battery['measurements']['battery_status']
+        # measurements_status=battery['measurements']['battery_status']
         #val_fullchargecapacity=float(measurements_status['fullchargecapacity']) #Ah
         #val_remainingcapacity=float(measurements_status['remainingcapacity']) #Ah
         #val_systemdcvoltage=float(measurements_status['systemdcvoltage']) #V, dont use this atm, use self.NormalBatteryVoltage=50.0

--- a/info.md
+++ b/info.md
@@ -1,0 +1,1 @@
+README.md


### PR DESCRIPTION
After contemplating this a bit I think it makes sense to provide separate settings for the values under `battery_settings` and `inverter['status']`. This makes it easier to cater for different setups of the whole system and gives the users more flexibility.
Changes in this PR:

- split out 'battery_system' information (`ppv`, `ipv`, `upv`)into own sensors (thanks @TobyRh)

  WARNING: This is possibly a breaking change! If your setup doesn't provide values for `ppv`, `ipv`
  and `upv` under the inverter settings, those values are lost and can now be found under new names:
  | before | after |
  |---|---|
  | `inverter_ipv` | `battery_system_ipv` |
  | `inverter_ppv` | `battery_system_ppv` |
  | `inverter_upv` | `battery_system_upv` |

  You can check your system's settings using [this gist](https://gist.github.com/RustyDust/2dfdd9e9d0f3b5476b5e466203123f6f)
- make GitHub actions work again
  - fix ordering of keys in manifest.json
  - update to actions@v3

- remove unused variable `measurements_status`