### PR TITLE
Change batterycount deviceclass and set notrun to 0

### DIFF
--- a/custom_components/sonnenbatterie/mappings.py
+++ b/custom_components/sonnenbatterie/mappings.py
@@ -91,8 +91,8 @@ SBmap = {
     "modules": {
       "sensor":         "module_count",
       "friendly_name":  "Battery module count",
-      "unit":           "",
-      "class":          SensorDeviceClass.BATTERY,
+      "unit":           None,
+      "class":          None,
     },
   },
   "inverter": {

--- a/custom_components/sonnenbatterie/sensor.py
+++ b/custom_components/sonnenbatterie/sensor.py
@@ -109,7 +109,7 @@ def generateDeviceInfo(configentry_id,systemdata):
 class SonnenBatterieSensor(CoordinatorEntity,SensorEntity):
     def __init__(self,id,deviceinfo,coordinator,name=None):
         self._attributes = {}
-        self._state = "NOTRUN"
+        self._state = "0"
         self._deviceinfo=deviceinfo
         self.coordinator=coordinator
         self.entity_id = id


### PR DESCRIPTION
I suggest setting the battery module count to deviceclass none so it does not count as a battery charge % information for the device. And also to use 0 instead of "NOTRUN", to get rid of warnings at startup when using Riemann Sum sensors that use Sonnenbatterie sensors.

I have also added logos in the official brands repo, so they will hopefully show up soon :)