### PR TITLE
Add new sensor `operating_mode` and it's textual counterpart

### DIFF
--- a/custom_components/sonnenbatterie/mappings.py
+++ b/custom_components/sonnenbatterie/mappings.py
@@ -220,7 +220,7 @@ SBmap = {
       "unit":           None,
       "class":          None,
       "convert":        int,
-      "textmap":        "{1:'Self Consumption', 2:'Auto', 10:'Time of Use'}"
+      "textmap":        "{1:'Self Consumption', 2:'Auto', 6:'Extension module', 10:'Time of Use'}"
     }
   }
 }

--- a/custom_components/sonnenbatterie/mappings.py
+++ b/custom_components/sonnenbatterie/mappings.py
@@ -34,6 +34,9 @@ A `<key definition>` has the following elements:
                         `keyval` is negative, 0 otherwiese
                         an `_output` one if `keyval` is positive, 0 otherwise
     `convert`:        Convert returned value to type ("int" or "float")
+    `textmap`:        Adds another sensor postfixed with _text to the 
+                      current sensor. The map needs to be specified in
+                      PYTHON synatx, not JSON!
 """
 
 SBmap = {
@@ -211,6 +214,14 @@ SBmap = {
       "unit":           None,
       "class":          None,
     },
+    "OperatingMode": {
+      "sensor":         "operating_mode",
+      "friendly_name":  "Operating Mode",
+      "unit":           None,
+      "class":          None,
+      "convert":        int,
+      "textmap":        "{1:'Self Consumption', 2:'Auto', 10:'Time of Use'}"
+    }
   }
 }
 """ Copy/Paste template ;)

--- a/custom_components/sonnenbatterie/sensor.py
+++ b/custom_components/sonnenbatterie/sensor.py
@@ -5,6 +5,7 @@ import sys
 from .const import *
 from .mappings import SBmap
 
+import ast
 # pylint: enable=unused-wildcard-import
 import threading
 import time
@@ -68,7 +69,6 @@ async def async_setup_entry(hass, config_entry,async_add_entities):
     coordinator = SonnenBatterieCoordinator(hass, sonnenInst, async_add_entities, updateIntervalSeconds, debug_mode,config_entry.entry_id)
 
     await coordinator.async_config_entry_first_refresh()
-    
     
     LOGGER.info('Init done')
     return True
@@ -363,6 +363,20 @@ class SonnenBatterieCoordinator(DataUpdateCoordinator):
                         entities["class"]
                     )
 
+                # do we have a text mapping?
+                if "textmap" in entities:
+                    tmap = ast.literal_eval(entities["textmap"])
+                    if real_val in tmap:
+                        tval = tmap[real_val]
+                    else:
+                        tval = "Unknown"
+                    self._AddOrUpdateEntity(
+                        "{}{}_{}".format(self.allSensorsPrefix, entities["sensor"], "text"),
+                        "{} (text)".format(entities["friendly_name"]),
+                        tval,
+                        entities["unit"],
+                        entities["class"]
+                    )
         else:
             # recursively check deeper down
             for elem in entities:


### PR DESCRIPTION
`operating_mode_text`.

To make thos possible a new conversion/mapping entity has been introduced in `mappings.py`:
- `textmap`: maps a given value to a textual representation. The map used is specified as a string represen- tation of a PYTHON map. DO NOT USE JSON syntax!