### PR TITLE
Fix `state_class` for newly created non-numeric sensors, closes #50

### DIFF
--- a/custom_components/sonnenbatterie/__init__.py
+++ b/custom_components/sonnenbatterie/__init__.py
@@ -1,17 +1,14 @@
 """The Sonnenbatterie integration."""
 from .const import *
 import json
-import asyncio
-import voluptuous as vol
-from homeassistant.helpers import config_validation as cv
-from homeassistant.helpers.entity import Entity
+# from homeassistant.helpers import config_validation as cv
+# from homeassistant.helpers.entity import Entity
 from homeassistant.const import (
     CONF_PASSWORD,
     CONF_USERNAME,
     CONF_IP_ADDRESS,
     CONF_SCAN_INTERVAL
 )
-
 
 
 async def async_setup(hass, config):
@@ -45,6 +42,4 @@ async def update_listener(hass, entry):
 async def async_unload_entry(hass, entry):
     """Handle removal of an entry."""
     return await hass.config_entries.async_forward_entry_unload(entry, 'sensor')
-
-
     

--- a/custom_components/sonnenbatterie/mappings.py
+++ b/custom_components/sonnenbatterie/mappings.py
@@ -37,6 +37,11 @@ A `<key definition>` has the following elements:
     `textmap`:        Adds another sensor postfixed with _text to the 
                       current sensor. The map needs to be specified in
                       PYTHON synatx, not JSON!
+                      The state_class (see below) will be set to `None``
+                      automatically.
+    `state_class`:    Override the default state class `measurement`with
+                      the value given here. For a list of valid classes see
+                      https://developers.home-assistant.io/docs/core/entity/sensor/
 """
 
 SBmap = {
@@ -213,6 +218,7 @@ SBmap = {
       "friendly_name":  "System Status",
       "unit":           None,
       "class":          None,
+      "state_class":    None,
     },
     "OperatingMode": {
       "sensor":         "operating_mode",


### PR DESCRIPTION
* When creating the sensors for the SonnenBatterie the code wrongly assumed all sensors to be numeric and assigned the `state_class` of `measurement` for them. Obviously this is plain wrong for pure text sensors which should have a `state_class` of None.
* removed some unused imports
* Added description for `state_class` entity to `mappings.py`
* Added Note that `textmap` entity types will always have a `state_class` of `None`
