### PR TITLE
Fix powermeter sensor unavailable if it should be "0" instead

### DIFF
--- a/custom_components/sonnenbatterie/sensor_list.py
+++ b/custom_components/sonnenbatterie/sensor_list.py
@@ -72,7 +72,7 @@ def generate_powermeter_sensors(_coordinator):
                                 _index
                             ].get(_sensor_meter)
                         )
-                        else None
+                        is not None else None
                     ),
                     entity_registry_enabled_default=False,
                 )


### PR DESCRIPTION
Add missing None check to fix powermeter sensors showing unavailable if the value should be "0" instead.

Fixes #59