### PR TITLE
Forward compat HA 2025.6

### DIFF
--- a/custom_components/sonnenbatterie/__init__.py
+++ b/custom_components/sonnenbatterie/__init__.py
@@ -5,10 +5,8 @@ import json
 
 # from homeassistant.helpers.entity import Entity
 from homeassistant.const import (
-    CONF_PASSWORD,
-    CONF_USERNAME,
-    CONF_IP_ADDRESS,
     CONF_SCAN_INTERVAL,
+    Platform
 )
 
 
@@ -26,9 +24,7 @@ async def async_setup(hass, config):
 async def async_setup_entry(hass, config_entry):
     LOGGER.info("setup_entry: " + json.dumps(dict(config_entry.data)))
 
-    await hass.async_create_task(
-        hass.config_entries.async_forward_entry_setup(config_entry, "sensor")
-    )
+    await hass.config_entries.async_forward_entry_setups(config_entry, [ Platform.SENSOR ])
     config_entry.add_update_listener(update_listener)
     config_entry.async_on_unload(config_entry.add_update_listener(async_reload_entry))
     return True

--- a/custom_components/sonnenbatterie/manifest.json
+++ b/custom_components/sonnenbatterie/manifest.json
@@ -7,5 +7,5 @@
     "documentation": "https://github.com/weltmeyer/ha_sonnenbatterie",
     "iot_class": "local_polling",
     "requirements": ["requests","sonnenbatterie>=0.1.1"],
-    "version": "2020.06.07"
+    "version": "2024.09.08"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,4 +1,5 @@
 {
   "name": "Sonnenbatterie",
-  "render_readme": true
+  "render_readme": true,
+  "homeassistant": "2024.9.0"
 }


### PR DESCRIPTION
+ Replace `async_forward_entry_setup` with `async_forward_entry_setups` for
  forward compatibility with HS 2025.6
+ Remove unnecessary imports from `__init.py__`
+ Prevent integration from installing on HA < 2024.9.0
+ Update version number in `manifest.json`