### PR TITLE
Relax unavailable API checks & overhaul of ConfigFlow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # ha_sonnenbatterie
 Homeassistant integration to show many stats of Sonnenbatterie
-
-Should work with current versions of Sonnenbatterie.
+that should work with current versions of Sonnenbatterie.
 
 [![Validate with hassfest](https://github.com/weltmeyer/ha_sonnenbatterie/actions/workflows/hassfest.yaml/badge.svg)](https://github.com/weltmeyer/ha_sonnenbatterie/actions/workflows/hassfest.yaml)
 
@@ -10,41 +9,30 @@ Should work with current versions of Sonnenbatterie.
 * eco 8.0 DE 9010 ND
 * sonnenBatterie 10 performance
 
-## Wont work with older Batteries
+## Won't work with older Batteries
 * ex. model 9.2 eco from 2014 not working
 
 ## Important: ###
-Set the update interval in the Integration Settings. Default is 10 seconds, which may kill your recorder database
+Set the update interval in the Integration Settings. Default is 30 seconds, don't
+go below 10 seconds otherwise you might encounter an exploding recorder database.
 
-### Unused/Unavailable sensors
+### Problems and/or Unused/Unavailable sensors
 Depending on the software on and the oparting mode of your Sonnenbatterie some
 values may not be available. The integration does it's best to detect the absence
 of these values. If a value isn't returned by your Sonnenbatterie you will see
 entries like the following in your log:
 
-```
-… WARNING (Thread-1 (watcher)) [custom_components.sonnenbatterie] No 'ppv2' in inverter -> sensor disabled
-… WARNING (Thread-1 (watcher)) [custom_components.sonnenbatterie] No 'ipv' in inverter -> sensor disabled
-… WARNING (Thread-1 (watcher)) [custom_components.sonnenbatterie] No 'ipv2' in inverter -> sensor disabled
-… WARNING (Thread-1 (watcher)) [custom_components.sonnenbatterie] No 'upv' in inverter -> sensor disabled
-… WARNING (Thread-1 (watcher)) [custom_components.sonnenbatterie] No 'upv2' in inverter -> sensor disabled
-```
-
-Those aren't errors! There's nothing to worry about. This just tells you that
-your Sonnenbatterie doesn't provide these values.
-
 If you feel that your Sonnenbatterie **should** provide one or more of those
 you can enable the "debug_mode" from
 
-_Settings -> Devices & Services -> Integrations -> Sonnenbatterie_
+_Settings -> Devices & Services -> Integrations -> Sonnenbatterie -> (...) -> Reconfigure_
 
-Just enable the "Debug mode" and restart your HomeAssistant instance. You'll get
-the full data that's returned by your Sonnenbatterie in the logs. Please put those
-logs along with the setting you want monitored into a new issue.
+Just enable the "Debug mode" and watch the logs of your HomeAssistant instance.
+You'll get the full data that's returned by your Sonnenbatterie in the logs. 
+Please put those logs along with the setting you want monitored into a new issue.
 
 ## Install
-Easiest way is to add this repository to hacs.
-
+Easiest way to add this repository is to use [HACS](https://hacs.xyz).
 
 ## Screenshots :)
 ![image](https://user-images.githubusercontent.com/1668465/78452159-ed2d7d80-7689-11ea-9e30-3a66ecc2372a.png)

--- a/custom_components/sonnenbatterie/__init__.py
+++ b/custom_components/sonnenbatterie/__init__.py
@@ -1,48 +1,44 @@
 """The Sonnenbatterie integration."""
 
-from .const import *
 import json
 
-# from homeassistant.helpers.entity import Entity
 from homeassistant.const import (
-    CONF_SCAN_INTERVAL,
     Platform
 )
 
+from .const import *
 
-async def async_setup(hass, config):
-    hass.data.setdefault(DOMAIN, {})
-    """Set up a skeleton component."""
-    # if DOMAIN not in config:
-    #    hass.states.async_set('sonnenbatterie.test', 'Works!')
-    #    return True
 
-    # hass.states.async_set('sonnenbatterie.test', 'Works!')
-    return True
+# rustydust_241227: this doesn't seem to be needed - kept until we're sure ;)
+# async def async_setup(hass, config):
+#     """Set up a skeleton component."""
+#     hass.data.setdefault(DOMAIN, {})
+#     return True
 
 
 async def async_setup_entry(hass, config_entry):
-    LOGGER.info("setup_entry: " + json.dumps(dict(config_entry.data)))
-
+    LOGGER.debug("setup_entry: " + json.dumps(dict(config_entry.data)))
     await hass.config_entries.async_forward_entry_setups(config_entry, [ Platform.SENSOR ])
-    config_entry.add_update_listener(update_listener)
+    # rustydust_241227: this doesn't seem to be needed
+    # config_entry.add_update_listener(update_listener)
     config_entry.async_on_unload(config_entry.add_update_listener(async_reload_entry))
     return True
 
 
 async def async_reload_entry(hass, entry):
-    """Reload config entry."""
-    await async_unload_entry(hass, entry)
-    await async_setup_entry(hass, entry)
+     """Reload config entry."""
+     await async_unload_entry(hass, entry)
+     await async_setup_entry(hass, entry)
 
 
-async def update_listener(hass, entry):
-    LOGGER.info("Update listener" + json.dumps(dict(entry.options)))
-    hass.data[DOMAIN][entry.entry_id]["monitor"].update_interval_seconds = (
-        entry.options.get(CONF_SCAN_INTERVAL)
-    )
+# rustydust_241227: this doesn't seem to be needed
+# async def update_listener(hass, entry):
+#     LOGGER.warning("Update listener" + json.dumps(dict(entry.options)))
+#     # hass.data[DOMAIN][entry.entry_id]["monitor"].update_interval_seconds = (
+#     #     entry.options.get(CONF_SCAN_INTERVAL)
+#     # )
 
 
 async def async_unload_entry(hass, entry):
     """Handle removal of an entry."""
-    return await hass.config_entries.async_forward_entry_unload(entry, "sensor")
+    return await hass.config_entries.async_forward_entry_unload(entry, Platform.SENSOR)

--- a/custom_components/sonnenbatterie/const.py
+++ b/custom_components/sonnenbatterie/const.py
@@ -1,44 +1,24 @@
 import logging
-import voluptuous as vol
 
-from homeassistant.const import (
-    CONF_PASSWORD,
-    CONF_USERNAME,
-    CONF_IP_ADDRESS,
-    CONF_SCAN_INTERVAL,
-)
+CONF_SERIAL_NUMBER = "serial_number"
+
+ATTR_SONNEN_DEBUG = "sonnenbatterie_debug"
+DOMAIN = "sonnenbatterie"
+
+DEFAULT_SCAN_INTERVAL = 30
+DEFAULT_SONNEN_DEBUG = False
 
 LOGGER = logging.getLogger(__package__)
 
-DOMAIN = "sonnenbatterie"
-DEFAULT_SCAN_INTERVAL = 30
-
-CONFIG_SCHEMA_A = vol.Schema(
-    {
-        vol.Required(CONF_USERNAME): vol.In(["User", "Installer"]),
-        vol.Required(CONF_PASSWORD): str,
-        vol.Required(CONF_IP_ADDRESS): str,
-    }
-)
-
-CONFIG_SCHEMA = vol.Schema(
-    {DOMAIN: CONFIG_SCHEMA_A},
-    extra=vol.ALLOW_EXTRA,
-)
-
-ATTR_SONNEN_DEBUG = "sonnenbatterie_debug"
-DEFAULT_SONNEN_DEBUG = False
-PLATFORMS = ["sensor"]
-
-
-def flatten_obj(prefix, seperator, obj):
-    result = {}
-    for field in obj:
-        val = obj[field]
-        val_prefix = prefix + seperator + field
-        if type(val) is dict:
-            sub = flatten_obj(val_prefix, seperator, val)
-            result.update(sub)
-        else:
-            result[val_prefix] = val
-    return result
+# rustydust_241227: doesn't seem to be used anywhere
+# def flatten_obj(prefix, seperator, obj):
+#     result = {}
+#     for field in obj:
+#         val = obj[field]
+#         val_prefix = prefix + seperator + field
+#         if type(val) is dict:
+#             sub = flatten_obj(val_prefix, seperator, val)
+#             result.update(sub)
+#         else:
+#             result[val_prefix] = val
+#     return result

--- a/custom_components/sonnenbatterie/const.py
+++ b/custom_components/sonnenbatterie/const.py
@@ -11,7 +11,7 @@ from homeassistant.const import (
 LOGGER = logging.getLogger(__package__)
 
 DOMAIN = "sonnenbatterie"
-DEFAULT_SCAN_INTERVAL = 10
+DEFAULT_SCAN_INTERVAL = 30
 
 CONFIG_SCHEMA_A = vol.Schema(
     {

--- a/custom_components/sonnenbatterie/coordinator.py
+++ b/custom_components/sonnenbatterie/coordinator.py
@@ -1,18 +1,17 @@
 """The data update coordinator for OctoPrint."""
 
+from time import time
 import traceback
-
-from .const import DOMAIN, LOGGER, logging
 from datetime import timedelta
 
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import (
-    CoordinatorEntity,
     DataUpdateCoordinator,
 )
-
 from sonnenbatterie import sonnenbatterie
-from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN, LOGGER, logging
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -60,6 +59,9 @@ class SonnenBatterieCoordinator(DataUpdateCoordinator):
         # placeholders, will be filled later
         self.serial = ""
 
+        # error tracking
+        self._last_error = None
+
     @property
     def device_info(self) -> DeviceInfo:
         system_data = self.latestData["system_data"]
@@ -73,46 +75,57 @@ class SonnenBatterieCoordinator(DataUpdateCoordinator):
             sw_version=system_data.get("software_version", "unknown"),
         )
 
+    # noinspection PyTypeChecker
     async def _async_update_data(self):
         """Fetch data from API endpoint.
-
         This is the place to pre-process the data to lookup tables
         so entities can quickly look up their data.
         """
+
         try:  # ignore errors here, may be transient
-            self.latestData["battery"] = await self.hass.async_add_executor_job(
-                self.sbInst.get_battery
-            )
-            self.latestData["battery_system"] = await self.hass.async_add_executor_job(
-                self.sbInst.get_batterysystem
-            )
-            self.latestData["inverter"] = await self.hass.async_add_executor_job(
-                self.sbInst.get_inverter
-            )
-            self.latestData["powermeter"] = await self.hass.async_add_executor_job(
-                self.sbInst.get_powermeter
-            )
-            self.latestData["status"] = await self.hass.async_add_executor_job(
-                self.sbInst.get_status
-            )
-            self.latestData["system_data"] = await self.hass.async_add_executor_job(
-                self.sbInst.get_systemdata
-            )
-            
-            if(isinstance(self.latestData["powermeter"],dict)):
-                try:
-                    #some new firmware of sonnenbatterie seems to send a dictionary, but we work with a list, so reformat :)
-                    newPowerMeters=[]
-                    for index,dictIndex in enumerate(self.latestData["powermeter"]):
-                        newPowerMeters.append(self.latestData["powermeter"][dictIndex])
-                    self.latestData["powermeter"]=newPowerMeters
-                    #LOGGER.warning("ReRead powermeter as it returned wrong from battery.")
-                except:
-                    e = traceback.format_exc()
-                    LOGGER.error(e)
-        except:
-            e = traceback.format_exc()
-            LOGGER.error(e)
+            result = await self.hass.async_add_executor_job(self.sbInst.get_battery)
+            self.latestData["battery"] = result
+
+            result = await self.hass.async_add_executor_job(self.sbInst.get_batterysystem)
+            self.latestData["battery_system"] = result
+
+            result = await self.hass.async_add_executor_job(self.sbInst.get_inverter)
+            self.latestData["inverter"] = result
+
+            result = await self.hass.async_add_executor_job(self.sbInst.get_powermeter)
+            self.latestData["powermeter"] = result
+
+            result = await self.hass.async_add_executor_job(self.sbInst.get_status)
+            self.latestData["status"] = result
+
+            result = await self.hass.async_add_executor_job(self.sbInst.get_systemdata)
+            self.latestData["system_data"] = result
+
+        except Exception as ex:
+            if self.debug:
+                e = traceback.format_exc()
+                LOGGER.error(e)
+            if self._last_error is not None:
+                elapsed = time() - self._last_error
+                if elapsed > timedelta(seconds=180).total_seconds():
+                    LOGGER.warning(f"Unable to connecto to Sonnenbatteries at {self.ip_address} for {elapsed} seconds. Please check! [{ex}]")
+            else:
+                self._last_error = time()
+
+        self._last_error = None
+
+        if isinstance(self.latestData.get("powermeter"), dict):
+            # noinspection PyBroadException
+            try:
+                # some new firmware of sonnenbatterie seems to send a dictionary, but we work with a list, so reformat :)
+                new_powermeters = []
+                for index, dictIndex in enumerate(self.latestData["powermeter"]):
+                    new_powermeters.append(self.latestData["powermeter"][dictIndex])
+                self.latestData["powermeter"] = new_powermeters
+                # LOGGER.warning("ReRead powermeter as it returned wrong from battery.")
+            except:
+                e = traceback.format_exc()
+                LOGGER.error(e)
 
         if self.debug:
             self.send_all_data_to_log()

--- a/custom_components/sonnenbatterie/coordinator.py
+++ b/custom_components/sonnenbatterie/coordinator.py
@@ -66,6 +66,7 @@ class SonnenBatterieCoordinator(DataUpdateCoordinator):
     def device_info(self) -> DeviceInfo:
         system_data = self.latestData["system_data"]
 
+        # noinspection HttpUrlsUsage
         return DeviceInfo(
             identifiers={(DOMAIN, self.device_id)},
             configuration_url=f"http://{self.ip_address}/",
@@ -122,7 +123,6 @@ class SonnenBatterieCoordinator(DataUpdateCoordinator):
                 for index, dictIndex in enumerate(self.latestData["powermeter"]):
                     new_powermeters.append(self.latestData["powermeter"][dictIndex])
                 self.latestData["powermeter"] = new_powermeters
-                # LOGGER.warning("ReRead powermeter as it returned wrong from battery.")
             except:
                 e = traceback.format_exc()
                 LOGGER.error(e)

--- a/custom_components/sonnenbatterie/manifest.json
+++ b/custom_components/sonnenbatterie/manifest.json
@@ -6,6 +6,6 @@
     "dependencies": [],
     "documentation": "https://github.com/weltmeyer/ha_sonnenbatterie",
     "iot_class": "local_polling",
-    "requirements": ["requests","sonnenbatterie>=0.1.1"],
-    "version": "2024.09.08"
+    "requirements": ["requests","sonnenbatterie>=0.3.0"],
+    "version": "2024.12.01"
 }

--- a/custom_components/sonnenbatterie/sensor.py
+++ b/custom_components/sonnenbatterie/sensor.py
@@ -10,11 +10,12 @@ from homeassistant.helpers.typing import StateType
 from .coordinator import SonnenBatterieCoordinator
 from sonnenbatterie import sonnenbatterie
 from .const import (
-    CONF_PASSWORD,
-    CONF_USERNAME,
-    CONF_IP_ADDRESS,
-    CONF_SCAN_INTERVAL,
     ATTR_SONNEN_DEBUG,
+    CONF_IP_ADDRESS,
+    CONF_PASSWORD,
+    CONF_SCAN_INTERVAL,
+    CONF_USERNAME,
+    DEFAULT_SCAN_INTERVAL,
     DOMAIN,
     LOGGER,
     logging,
@@ -51,7 +52,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     sonnenInst = await hass.async_add_executor_job(
         _internal_setup, username, password, ip_address
     )
-    update_interval_seconds = update_interval_seconds or 1
+    update_interval_seconds = update_interval_seconds or DEFAULT_SCAN_INTERVAL
     LOGGER.info("{0} - UPDATEINTERVAL: {1}".format(DOMAIN, update_interval_seconds))
 
     """ The Coordinator is called from HA for updates from API """
@@ -69,7 +70,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     async_add_entities(
         SonnenbatterieSensor(coordinator=coordinator, entity_description=description)
         for description in SENSORS
-        if description.value_fn(coordinator=coordinator) is not None
+        if description.value_fn(coordinator) is not None
     )
 
     async_add_entities(

--- a/custom_components/sonnenbatterie/sensor.py
+++ b/custom_components/sonnenbatterie/sensor.py
@@ -1,20 +1,23 @@
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
-    DataUpdateCoordinator,
 )
 from homeassistant.components.sensor import (
     SensorEntity,
 )
+from homeassistant.const import (
+    CONF_IP_ADDRESS,
+    CONF_PASSWORD,
+    CONF_SCAN_INTERVAL,
+    CONF_USERNAME,
+)
+
 from homeassistant.helpers.typing import StateType
 
 from .coordinator import SonnenBatterieCoordinator
 from sonnenbatterie import sonnenbatterie
 from .const import (
     ATTR_SONNEN_DEBUG,
-    CONF_IP_ADDRESS,
-    CONF_PASSWORD,
-    CONF_SCAN_INTERVAL,
-    CONF_USERNAME,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
     LOGGER,
@@ -29,43 +32,44 @@ from .sensor_list import (
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_unload_entry(hass, entry):
-    """Unload a config entry."""
-    ## we dont have anything special going on.. unload should just work, right?
-    ##bridge = hass.data[DOMAIN].pop(entry.data['host'])
-    return
+# rustydust_241227: this doesn't seem to be used anywhere
+# async def async_unload_entry(hass, entry):
+#     """Unload a config entry."""
+#     ## we dont have anything special going on.. unload should just work, right?
+#     ##bridge = hass.data[DOMAIN].pop(entry.data['host'])
+#     return
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the sensor platform."""
     LOGGER.info("SETUP_ENTRY")
-    # await async_setup_reload_service(hass, DOMAIN, PLATFORMS)
     username = config_entry.data.get(CONF_USERNAME)
     password = config_entry.data.get(CONF_PASSWORD)
     ip_address = config_entry.data.get(CONF_IP_ADDRESS)
-    update_interval_seconds = config_entry.options.get(CONF_SCAN_INTERVAL)
-    debug_mode = config_entry.options.get(ATTR_SONNEN_DEBUG)
+    update_interval_seconds = config_entry.data.get(CONF_SCAN_INTERVAL)
+    debug_mode = config_entry.data.get(ATTR_SONNEN_DEBUG)
 
-    def _internal_setup(_username, _password, _ip_address):
-        return sonnenbatterie(_username, _password, _ip_address)
-
-    sonnenInst = await hass.async_add_executor_job(
-        _internal_setup, username, password, ip_address
+    sonnen_inst = await hass.async_add_executor_job(
+        sonnenbatterie, username, password, ip_address
     )
+
     update_interval_seconds = update_interval_seconds or DEFAULT_SCAN_INTERVAL
     LOGGER.info("{0} - UPDATEINTERVAL: {1}".format(DOMAIN, update_interval_seconds))
 
     """ The Coordinator is called from HA for updates from API """
     coordinator = SonnenBatterieCoordinator(
         hass,
-        sonnenInst,
+        sonnen_inst,
         update_interval_seconds,
         ip_address,
         debug_mode,
         config_entry.entry_id,
     )
 
-    await coordinator.async_config_entry_first_refresh()
+    if config_entry.state == ConfigEntryState.SETUP_IN_PROGRESS:
+        await coordinator.async_config_entry_first_refresh()
+    else:
+        await coordinator.async_refresh()
 
     async_add_entities(
         SonnenbatterieSensor(coordinator=coordinator, entity_description=description)

--- a/custom_components/sonnenbatterie/sensor_list.py
+++ b/custom_components/sonnenbatterie/sensor_list.py
@@ -131,7 +131,7 @@ SENSORS: tuple[SonnenbatterieSensorEntityDescription, ...] = (
             # Prevent having small negative values in production at night
             0
             if (
-                production := coordinator.latestData.get("status").get(
+                production := coordinator.latestData.get("status", {}).get(
                     "Production_W", 0
                 )
             )

--- a/custom_components/sonnenbatterie/translations/de.json
+++ b/custom_components/sonnenbatterie/translations/de.json
@@ -14,21 +14,22 @@
                     "password": "Passwort",
                     "username": "Benutzer",
                     "ip_address": "IP-Adresse",
-                    "scan_interval": "Aktualisierungsinterval (Sekunden)"
-                },
-                "title": "Gib deine Sonnenbatterie-Anmeldeinformationen ein",
-                "description": "Dein Passwort findest du normalerweise an der Seite deiner Sonnenbatterie in der Nähe des Hauptschalters."
-            }
-
-        }
-    },
-    "options": {
-        "step":{
-            "init":{
-                "data":{
                     "scan_interval": "Aktualisierungsinterval (Sekunden)",
                     "sonnenbatterie_debug": "Debug-Modus (mehr Logs)"
-                }
+                },
+                "title": "Sonnenbatterie-Konfiguration",
+                "description": "Dein Passwort findest du normalerweise an der Seite deiner Sonnenbatterie in der Nähe des Hauptschalters."
+            },
+            "reconfigure": {
+                "data": {
+                    "password": "Passwort",
+                    "username": "Benutzer",
+                    "ip_address": "IP-Adresse",
+                    "scan_interval": "Aktualisierungsinterval (Sekunden)",
+                    "sonnenbatterie_debug": "Debug-Modus (mehr Logs)"
+                },
+                "title": "Sonnenbatterie-Konfiguration",
+                "description": "Dein Passwort findest du normalerweise an der Seite deiner Sonnenbatterie in der Nähe des Hauptschalters."
             }
         }
     },

--- a/custom_components/sonnenbatterie/translations/en.json
+++ b/custom_components/sonnenbatterie/translations/en.json
@@ -14,21 +14,22 @@
                     "password": "Password",
                     "username": "User",
                     "ip_address": "IP-Address",
-                    "scan_interval": "Update interval (seconds)"
-                },
-                "title": "Enter your Sonnenbatterie-login information",
-                "description": "Normally you find your password on the side of your sonnenbatterie near the main switch."
-            }
-
-        }
-    },
-    "options": {
-        "step": {
-            "init": {
-                "data": {
                     "scan_interval": "Update interval (seconds)",
                     "sonnenbatterie_debug": "Debug mode (more log entries)"
-                }
+                },
+                "title": "Configure your Sonnenbatterie",
+                "description": "Normally you find your password on the side of your sonnenbatterie near the main switch."
+            },
+            "reconfigure": {
+                "data": {
+                    "password": "Password",
+                    "username": "User",
+                    "ip_address": "IP-Address",
+                    "scan_interval": "Update interval (seconds)",
+                    "sonnenbatterie_debug": "Debug mode (more log entries)"
+                },
+                "title": "Configure your Sonnenbatterie",
+                "description": "Normally you find your password on the side of your sonnenbatterie near the main switch."
             }
         }
     },


### PR DESCRIPTION
- Make sure the default scan interval is honored even if not set by user
- Make sure old values aren't overwritten in case of connection error (fixes #70)
- Be lenient to connection errors for ~3 mins (Sonnenbatterie maintenance interval)
- Fix minor oversight in sensor_list.py
- Silence/fix some PEP hints from IDE
- Update version, require sonnenbatterie >= 0.3.0
- Moved "options" to basic configuration
  - `scan_interval` and `debug_mode` can now be set under the (...) menu
    using the "Reconfigure" option
- Made configuration editable by providing `async_setup_reconfigure` function (see above)
- Added serial number to device in integration overview
- Disabled `OptionsFlowHandler` class since there are no more options ;)
- Disabled some functions that were never called
- Reworked config reload to be compatible with HA 2025.1 onward (fixes #69)
- Added/removed translations where appropriate
- Removed unused constants
- Fixed a bug that caused the sensors to be read every second thereby causing unnecessary load
- Updated README