### PR TITLE
Rework some services to return more consistent responses:

### DIFF
--- a/.github/workflows/hassfest.yaml
+++ b/.github/workflows/hassfest.yaml
@@ -4,7 +4,7 @@ on:
   push:
   pull_request:
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "0 0 * * 0"
 
 jobs:
   validate:

--- a/README.md
+++ b/README.md
@@ -100,6 +100,27 @@ data:
 ```
 
 ##### Response
+The name of the mode that has been set:
+- `manual`
+- `automatic`
+- `timeofuse`
+
+### <a name="set_operatingmode_num"></a>`set_operating_mode_num(mode=<mode>)`
+- Sets the operating mode of your SonnenBatterie.
+- Supported values for `<mode>` are:
+  - `1`
+  - `2`
+  - `10`
+
+##### Code snippet
+``` yaml
+action: sonnenbatterie.set_operating_mode_num
+data:
+  device_id: "<your sb instance's device id>"
+  mode: 2
+```
+
+##### Response
 An `int` representing the mode that has been set:
 - 1: `manual`
 - 2: `automatic`
@@ -275,6 +296,38 @@ data:
   "schedule": [{"start": "10:00", "stop": "10:00", "threshold_p_max": 20000}]
 }
 ```
+
+### <a name="get_operatingmode"></a>`get_operating_mode()`
+- Retrieves the current operating mode of your SonnenBatterie.
+
+##### Code snippet
+``` yaml
+action: sonnenbatterie.get_operating_mode
+data:
+  device_id: "<your sb instance's device id>"
+```
+
+##### Response
+The name of the mode that has been set:
+- `manual`
+- `automatic`
+- `timeofuse`
+
+### <a name="get_operatingmode_num"></a>`get_operating_mode_num()`
+- Retrieves the current operating mode of your SonnenBatterie in numeric form
+
+##### Code snippet
+``` yaml
+action: sonnenbatterie.get_operating_mode_num
+data:
+  device_id: "<your sb instance's device id>"
+```
+
+##### Response
+An `int` representing the mode that has been set:
+- 1: `manual`
+- 2: `automatic`
+- 10: `timeofuse`
 
 ## Problems and/or unused/unavailable sensors
 Depending on the software on and the operating mode of your Sonnenbatterie some

--- a/custom_components/sonnenbatterie/__init__.py
+++ b/custom_components/sonnenbatterie/__init__.py
@@ -40,6 +40,13 @@ SCHEMA_SET_OPERATING_MODE = vol.Schema(
     }
 )
 
+SCHEMA_SET_OPERATING_MODE_NUM = vol.Schema(
+    {
+        **cv.ENTITY_SERVICE_FIELDS,
+        vol.Required(CONF_SERVICE_MODE, default=2): vol.In(CONF_OPERATING_MODES_NUM),
+    }
+)
+
 SCHEMA_SET_TOU_SCHEDULE_STRING = vol.Schema(
     {
         **cv.ENTITY_SERVICE_FIELDS,
@@ -157,6 +164,14 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
 
     hass.services.async_register(
         DOMAIN,
+        "set_operating_mode_num",
+        services.set_operating_mode_num,
+        schema=SCHEMA_SET_OPERATING_MODE_NUM,
+        supports_response=SupportsResponse.OPTIONAL,
+    )
+
+    hass.services.async_register(
+        DOMAIN,
         "set_tou_schedule",
         services.set_tou_schedule,
         schema=SCHEMA_SET_TOU_SCHEDULE_STRING,
@@ -181,6 +196,13 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         DOMAIN,
         "get_operating_mode",
         services.get_operating_mode,
+        supports_response=SupportsResponse.OPTIONAL,
+    )
+
+    hass.services.async_register(
+        DOMAIN,
+        "get_operating_mode_num",
+        services.get_operating_mode_num,
         supports_response=SupportsResponse.OPTIONAL,
     )
 

--- a/custom_components/sonnenbatterie/const.py
+++ b/custom_components/sonnenbatterie/const.py
@@ -29,9 +29,9 @@ CONF_OPERATING_MODES = [
 ]
 
 CONF_OPERATING_MODES_NUM = [
-    1,
-    2,
-    10
+    "1",
+    "2",
+    "10"
 ]
 
 CONF_CHARGE_WATT  = "power"

--- a/custom_components/sonnenbatterie/const.py
+++ b/custom_components/sonnenbatterie/const.py
@@ -28,6 +28,12 @@ CONF_OPERATING_MODES = [
     "timeofuse"
 ]
 
+CONF_OPERATING_MODES_NUM = [
+    1,
+    2,
+    10
+]
+
 CONF_CHARGE_WATT  = "power"
 CONF_COORDINATOR = "coordinator"
 CONF_INVERTER_MAX = "inverter_max"

--- a/custom_components/sonnenbatterie/manifest.json
+++ b/custom_components/sonnenbatterie/manifest.json
@@ -8,5 +8,5 @@
     "iot_class": "local_polling",
     "issue_tracker": "https://github.com/weltmeyer/ha_sonnenbatterie/issues",
     "requirements": ["requests","sonnenbatterie>=0.5.2"],
-    "version": "2025.01.03"
+    "version": "2025.02.01"
 }

--- a/custom_components/sonnenbatterie/service.py
+++ b/custom_components/sonnenbatterie/service.py
@@ -17,6 +17,7 @@ from custom_components.sonnenbatterie.const import (
     DOMAIN,
     LOGGER,
     SB_OPERATING_MODES,
+    SB_OPERATING_MODES_NUM,
     SONNENBATTERIE_ISSUE_URL,
 )
 
@@ -55,9 +56,7 @@ class SonnenbatterieService:
             power = 0
         # Make sure we have an sb2 object
         sb_conn = self._get_sb_connection(call.data)
-        # await sb_conn.login()
         response = await sb_conn.sb2.charge_battery(power)
-        # await sb_conn.logout()
         return {
             "charge": response,
         }
@@ -68,9 +67,7 @@ class SonnenbatterieService:
         if power < 0:
             power = 0
         sb_conn = self._get_sb_connection(call.data)
-        # await sb_conn.login()
         response = await sb_conn.sb2.discharge_battery(power)
-        # await sb_conn.logout()
         return {
             "discharge": response,
         }
@@ -78,9 +75,7 @@ class SonnenbatterieService:
     async def set_battery_reserve(self, call: ServiceCall) -> ServiceResponse:
         value = call.data.get(CONF_SERVICE_VALUE)
         sb_conn = self._get_sb_connection(call.data)
-        # await sb_conn.login()
         response = int((await sb_conn.sb2.set_battery_reserve(value))["EM_USOC"])
-        # await sb_conn.logout()
         return {
             "battery_reserve": response,
         }
@@ -89,9 +84,7 @@ class SonnenbatterieService:
         item = call.data.get(CONF_SERVICE_ITEM)
         value = call.data.get(CONF_SERVICE_VALUE)
         sb_conn = self._get_sb_connection(call.data)
-        # await sb_conn.login()
         response = await sb_conn.sb2.set_config_item(item, value)
-        # await sb_conn.logout()
         return {
             "response": response,
         }
@@ -99,11 +92,17 @@ class SonnenbatterieService:
     async def set_operating_mode(self, call: ServiceCall) -> ServiceResponse:
         mode = SB_OPERATING_MODES.get(call.data.get('mode'))
         sb_conn = self._get_sb_connection(call.data)
-        # await sb_conn.login()
         response = await sb_conn.set_operating_mode(mode)
-        # await sb_conn.logout()
         return {
-            "mode": response,
+            "mode": SB_OPERATING_MODES_NUM.get(str(response), "UNKNOWN")
+        }
+
+    async def set_operating_mode_num(self, call: ServiceCall) -> ServiceResponse:
+        mode = call.data.get('mode')
+        sb_conn = self._get_sb_connection(call.data)
+        response = await sb_conn.set_operating_mode(mode)
+        return {
+            "mode": response
         }
 
     async def set_tou_schedule(self, call: ServiceCall) -> ServiceResponse:
@@ -122,9 +121,7 @@ class SonnenbatterieService:
             raise HomeAssistantError(f"Schedule is not a valid schedule: '{schedule}'") from t
 
         sb_conn = self._get_sb_connection(call.data)
-        # await sb_conn.login()
         response = await sb_conn.sb2.set_tou_schedule_string(schedule)
-        # await sb_conn.logout()
         return {
             "schedule": response["EM_ToU_Schedule"],
         }
@@ -132,9 +129,7 @@ class SonnenbatterieService:
     # noinspection PyUnusedLocal
     async def get_tou_schedule(self, call: ServiceCall) -> ServiceResponse:
         sb_conn = self._get_sb_connection(call.data)
-        # await sb_conn.login()
         response = await sb_conn.sb2.get_tou_schedule_string()
-        # await sb_conn.logout()
         return {
             "schedule": response,
         }
@@ -142,18 +137,21 @@ class SonnenbatterieService:
     # noinspection PyUnusedLocal
     async def get_battery_reserve(self, call: ServiceCall) -> ServiceResponse:
         sb_conn = self._get_sb_connection(call.data)
-        # await sb_conn.login()
         response = await sb_conn.sb2.get_battery_reserve()
-        # await sb_conn.logout()
         return {
             "backup_reserve": response,
         }
 
     async def get_operating_mode(self, call: ServiceCall) -> ServiceResponse:
         sb_conn = self._get_sb_connection(call.data)
-        # await sb_conn.login()
         response = await sb_conn.sb2.get_operating_mode()
-        # await sb_conn.logout()
+        return {
+            "operating_mode": SB_OPERATING_MODES_NUM.get(str(response), "UNKNOWN")
+        }
+
+    async def get_operating_mode_num(self, call: ServiceCall) -> ServiceResponse:
+        sb_conn = self._get_sb_connection(call.data)
+        response = await sb_conn.sb2.get_operating_mode()
         return {
             "operating_mode": response,
         }

--- a/custom_components/sonnenbatterie/services.yaml
+++ b/custom_components/sonnenbatterie/services.yaml
@@ -10,7 +10,28 @@ set_operating_mode:
       example: "timeofuse"
       default: "automatic"
       selector:
-        text:
+        select:
+          options:
+            - "manual"
+            - "automatic"
+            - "timeofuse"
+set_operating_mode_num:
+  fields:
+    device_id:
+      required: true
+      selector:
+        device:
+          integration: sonnenbatterie
+    mode:
+      required: true
+      example: 10
+      default: 2
+      selector:
+        select:
+          options:
+            - 1
+            - 2
+            - 10
 charge_battery:
   fields:
     device_id:
@@ -94,6 +115,13 @@ get_battery_reserve:
         device:
           integration: sonnenbatterie
 get_operating_mode:
+  fields:
+    device_id:
+      required: true
+      selector:
+        device:
+          integration: sonnenbatterie
+get_operating_mode_num:
   fields:
     device_id:
       required: true

--- a/custom_components/sonnenbatterie/services.yaml
+++ b/custom_components/sonnenbatterie/services.yaml
@@ -29,9 +29,9 @@ set_operating_mode_num:
       selector:
         select:
           options:
-            - 1
-            - 2
-            - 10
+            - "1"
+            - "2"
+            - "10"
 charge_battery:
   fields:
     device_id:

--- a/custom_components/sonnenbatterie/translations/de.json
+++ b/custom_components/sonnenbatterie/translations/de.json
@@ -194,6 +194,22 @@
                 }
             }
         },
+        "set_operating_mode_num": {
+            "name": "Setze numerischen Sonnenbatterie-Betriebsmodus",
+            "description": "Setzt den numerischen Betriebsmodus der Sonnenbatterie",
+            "fields": {
+                "device_id": {
+                    "description": "HomeAssistant ID des Geräts",
+                    "name": "Device ID",
+                    "example": "1234567890"
+                },
+                "mode": {
+                    "description": "Der zu setzende numerische Betriebsmodus ('1', '2', '10')",
+                    "name": "Betriebsmodus",
+                    "example": "2"
+                }
+            }
+        },
         "charge_battery": {
             "name": "Sonnenbatterie laden",
             "description": "Erzwingt das Laden der Sonnenbatterie mit der angegebenen Leistung",
@@ -303,7 +319,18 @@
         },
         "get_operating_mode": {
             "name": "Betriebsmodus auslesen",
-            "description": "Liefert den aktuellen Betriebsmodus der Sonnebatterie in numerischer Form",
+            "description": "Liefert den aktuellen Betriebsmodus der Sonnenbatterie in Textform",
+            "fields": {
+                "device_id": {
+                    "description": "HomeAssistant ID des Geräts",
+                    "name": "Device ID",
+                    "example": "1234567890"
+                }
+            }
+        },
+        "get_operating_mode_num": {
+            "name": "Betriebsmodus auslesen (numerisch)",
+            "description": "Liefert den aktuellen Betriebsmodus der Sonnenbatterie in numerischer Form",
             "fields": {
                 "device_id": {
                     "description": "HomeAssistant ID des Geräts",

--- a/custom_components/sonnenbatterie/translations/en.json
+++ b/custom_components/sonnenbatterie/translations/en.json
@@ -178,20 +178,36 @@
             }
         }
     },
-        "services": {
+    "services": {
         "set_operating_mode": {
             "name": "Set operating mode",
             "description": "Sets the operating mode of the Sonnenbatterie",
             "fields": {
                 "device_id": {
                     "description": "HomeAssistant Id of the target device",
-                    "name": "Device Id",
-                    "example": "1234567890"
+                    "example": "1234567890",
+                    "name": "Device Id"
                 },
                 "mode": {
                     "description": "Operating mode to set ('manual', 'automatic', 'timeofuse')",
                     "name": "Operating mode",
                     "example": "automatic"
+                }
+            }
+        },
+        "set_operating_mode_num": {
+            "name": "Set operating mode (numeric)",
+            "description": "Sets the numeric operating mode of the Sonnenbatterie",
+            "fields": {
+                "device_id": {
+                    "description": "HomeAssistant Id of the target device",
+                    "name": "Device ID",
+                    "example": "1234567890"
+                },
+                "mode": {
+                    "description": "Operating mode to set ('1', '2', '10')",
+                    "name": "Operating mode",
+                    "example": "2"
                 }
             }
         },
@@ -304,6 +320,17 @@
         },
         "get_operating_mode": {
             "name": "Get operating mode",
+            "description": "Returns the current operating mode of the SonnenBatterie in textual form",
+            "fields": {
+                "device_id": {
+                    "description": "HomeAssistant ID of the target device",
+                    "name": "Device ID",
+                    "example": "1234567890"
+                }
+            }
+        },
+        "get_operating_mode_num": {
+            "name": "Get operating mode (numeric)",
             "description": "Returns the current operating mode of the SonnenBatterie in numeric form",
             "fields": {
                 "device_id": {
@@ -313,5 +340,5 @@
                 }
             }
         }
-}
+    }
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
   "name": "Sonnenbatterie",
   "render_readme": true,
-  "homeassistant": "2024.9.0"
+  "homeassistant": "2025.2.0"
 }


### PR DESCRIPTION
- make `set_operating_mode` return the textual representation of the operating mode
- make `get_operating_mode` return the textual representation of the operation mode
- introduce new service `set_operating_mode_num` that accepts a numeric value for the mode to set and in turn also returns the numeric value of the mode that has been set
- introduce new service `get_operating_mode_num` that returns the numeric operating mode value

Added the new service descriptions to README.md and also added the formerly forgotten `get_operating_mode` description.

Removed some unused older code.

Updated HA requirement to 2025.2.0