### PR TITLE
Cleanups and fixes:

### DIFF
--- a/custom_components/sonnenbatterie/button.py
+++ b/custom_components/sonnenbatterie/button.py
@@ -13,13 +13,16 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, asyn
     LOGGER.debug(f"BUTTON async_setup_entry - {config_entry}")
     coordinator = hass.data[DOMAIN][config_entry.entry_id][CONF_COORDINATOR]
 
-    entities = []
-    for description in BUTTON_ENTITIES:
-        if description.tag.type == Platform.BUTTON:
-            entity = SonnenbatterieButton(coordinator, description)
-            entities.append(entity)
+    if coordinator.latestData.get('api_configuration', {}).get('IN_LocalAPIWriteActive', '0') == '1':
+        entities = []
+        for description in BUTTON_ENTITIES:
+            if description.tag.type == Platform.BUTTON:
+                entity = SonnenbatterieButton(coordinator, description)
+                entities.append(entity)
 
-    async_add_entities(entities)
+        async_add_entities(entities)
+    else:
+        LOGGER.info(f"JSON-API write access not enabled - disabling BUTTON functions")
 
 class SonnenbatterieButton(SonnenButtonEntity, ButtonEntity):
 

--- a/custom_components/sonnenbatterie/const.py
+++ b/custom_components/sonnenbatterie/const.py
@@ -37,6 +37,7 @@ CONF_OPERATING_MODES_NUM = [
 CONF_CHARGE_WATT  = "power"
 CONF_COORDINATOR = "coordinator"
 CONF_INVERTER_MAX = "inverter_max"
+CONF_TOU_MAX = "tou_max"
 CONF_SERVICE_ITEM = "item"
 CONF_SERVICE_MODE = "mode"
 CONF_SERVICE_SCHEDULE = "schedule"

--- a/custom_components/sonnenbatterie/coordinator.py
+++ b/custom_components/sonnenbatterie/coordinator.py
@@ -117,6 +117,12 @@ class SonnenbatterieCoordinator(DataUpdateCoordinator):
             result = await self.sbconn.sb2.get_configurations()
             self.latestData["configurations"] = result
 
+            result = await self.sbconn.get_api_configuration()
+            self.latestData["api_configuration"] = result
+
+            result = await self.sbconn.get_commissioning_settings()
+            self.latestData["commissioning_settings"] = result
+
             self._last_error = None
 
         except Exception as e:
@@ -165,4 +171,5 @@ class SonnenbatterieCoordinator(DataUpdateCoordinator):
             LOGGER.warning(f"System data:\n{self.latestData['system_data']}")
             LOGGER.warning(f"Status:\n{self.latestData['status']}")
             LOGGER.warning(f"Battery:\n{self.latestData['battery']}")
+            LOGGER.warning(f"API-Config:\n{self.latestData['api_configuration']}")
             self._fullLogsAlreadySent = True

--- a/custom_components/sonnenbatterie/manifest.json
+++ b/custom_components/sonnenbatterie/manifest.json
@@ -8,5 +8,5 @@
     "iot_class": "local_polling",
     "issue_tracker": "https://github.com/weltmeyer/ha_sonnenbatterie/issues",
     "requirements": ["requests","sonnenbatterie>=0.6.0"],
-    "version": "2025.02.01"
+    "version": "2025.02.02"
 }

--- a/custom_components/sonnenbatterie/manifest.json
+++ b/custom_components/sonnenbatterie/manifest.json
@@ -7,6 +7,6 @@
     "documentation": "https://github.com/weltmeyer/ha_sonnenbatterie",
     "iot_class": "local_polling",
     "issue_tracker": "https://github.com/weltmeyer/ha_sonnenbatterie/issues",
-    "requirements": ["requests","sonnenbatterie>=0.5.2"],
+    "requirements": ["requests","sonnenbatterie>=0.6.0"],
     "version": "2025.02.01"
 }

--- a/custom_components/sonnenbatterie/select.py
+++ b/custom_components/sonnenbatterie/select.py
@@ -15,15 +15,19 @@ async def async_setup_entry(
 ) -> None:
     LOGGER.debug(f"SELECT async_setup_entry: {config_entry}")
     coordinator = hass.data[DOMAIN][config_entry.entry_id][CONF_COORDINATOR]
-    await coordinator.async_refresh()
 
-    entities = []
-    for description in SELECT_ENTITIES:
-        entity = SonnenBatterieSelect(coordinator, description)
-        entities.append(entity)
+    if coordinator.latestData.get('api_configuration',{}).get('IN_LocalAPIWriteActive', '0') == '1':
+        # await coordinator.async_refresh()
 
-    async_entity_cb(entities) if len(entities) > 0 else None
+        entities = []
+        for description in SELECT_ENTITIES:
+            entity = SonnenBatterieSelect(coordinator, description)
+            entities.append(entity)
 
+        async_entity_cb(entities) if len(entities) > 0 else None
+
+    else:
+        LOGGER.info(f"JSON-API write access not enabled - disabling SELECT functions")
 
 class SonnenBatterieSelect(SonnenSelectEntity, SelectEntity):
     def __init__(self, coordinator: SonnenbatterieCoordinator, description: SonnenbatterieSelectEntityDescription):

--- a/custom_components/sonnenbatterie/sensor.py
+++ b/custom_components/sonnenbatterie/sensor.py
@@ -32,7 +32,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     LOGGER.debug(f"SENSOR async_setup_entry - {config_entry.data}")
     coordinator = hass.data[DOMAIN][config_entry.entry_id][CONF_COORDINATOR]
 
-    await coordinator.async_refresh()
+    # await coordinator.async_refresh()
 
     async_add_entities(
         SonnenbatterieSensor(coordinator=coordinator, entity_description=description)

--- a/custom_components/sonnenbatterie/sensor_list.py
+++ b/custom_components/sonnenbatterie/sensor_list.py
@@ -517,4 +517,34 @@ SENSORS: tuple[SonnenbatterieSensorEntityDescription, ...] = (
         .get("tmax"),
         entity_registry_enabled_default=False,
     ),
+    ###########################
+    ### -- advanced sensors ###
+    ###
+    SonnenbatterieSensorEntityDescription(
+        key="read_api",
+        icon="mdi:alpha-r-circle-outline",
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda coordinator: coordinator.latestData.get("api_configuration", {})
+        .get('IN_LocalAPIReadActive', '0') == '1',
+        entity_registry_enabled_default=True,
+    ),
+    SonnenbatterieSensorEntityDescription(
+        key="write_api",
+        icon="mdi:alpha-w-circle-outline",
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn= lambda coordinator: coordinator.latestData.get("api_configuration", {})
+        .get('IN_LocalAPIWriteActive', '0') == '1',
+        entity_registry_enabled_default = True,
+    ),
+    SonnenbatterieSensorEntityDescription(
+        key="tou_max_power",
+        icon="mdi:transmission-tower-import",
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda coordinator: coordinator.latestData.get("commissioning_settings", {})
+                                     .get('data', {}).get('attributes',{}).get('tou_max_power_limit', 'unknown'),
+        entity_registry_enabled_default=True,
+    )
 )

--- a/custom_components/sonnenbatterie/translations/de.json
+++ b/custom_components/sonnenbatterie/translations/de.json
@@ -174,6 +174,15 @@
             },
             "inverter_state_upv2": {
                 "name": "Spannungswandler UPV 2"
+            },
+            "read_api": {
+                "name": "Lesezugriff JSON-API"
+            },
+            "write_api": {
+                "name": "Schreibzugriff JSON-API"
+            },
+            "tou_max_power": {
+                "name": "Maximaler ToU Netzbezug"
             }
         }
     },

--- a/custom_components/sonnenbatterie/translations/en.json
+++ b/custom_components/sonnenbatterie/translations/en.json
@@ -175,6 +175,15 @@
             },
             "inverter_state_upv2": {
                 "name": "Inverter UPV 2"
+            },
+            "read_api": {
+                "name": "JSON-API read access"
+            },
+            "write_api": {
+                "name": "JSON-API write access"
+            },
+            "tou_max_power": {
+                "name": "ToU max power consumption"
             }
         }
     },


### PR DESCRIPTION
- Check for active write API before enabling services, actions, selects, numbers and buttons. Fixes #86. Thanks @Prythi
- Due to the new check requires `python_sonnebatterie` >= 0.6.0
- Removed unnecessary calls to `coordinator.async_refresh()` when initializing services, actions, selects, numbers and buttons which results in slightly faster startup time
- Add three new diagnostic sensors:
  - `read_api`: whether the v2 JSON-API read access is enabled
  - `write_api`: whether the v2 JSON-API write access is enabled
  - `tou_max`: displays the configured limit for `threshold_p_max` on ToU
- Enforce the configured `tou_max` limit on calls to `set_tou_schedule()`