### PR TITLE
Fix entity domain mismatch error

### DIFF
--- a/custom_components/sonnenbatterie/entities.py
+++ b/custom_components/sonnenbatterie/entities.py
@@ -98,8 +98,6 @@ class SonnenBaseEntity(CoordinatorEntity[SonnenbatterieCoordinator], Entity):
         super().__init__(coordinator=coordinator)
         self.coordinator = coordinator
         self.entity_description = description
-        # {DOMAIN} is replaced by the correct platform by HA
-        self.entity_id = f"{DOMAIN}.{DOMAIN}_{self.coordinator.serial}_{self.entity_description.key}"
 
         # set the device info
         self._attr_device_info = self.coordinator.device_info
@@ -113,7 +111,8 @@ class SonnenBaseEntity(CoordinatorEntity[SonnenbatterieCoordinator], Entity):
 
     @property
     def unique_id(self) -> str:
-        return self.entity_id
+        key = self.entity_description.legacy_key or self.entity_description.key
+        return f"sonnenbatterie_{self.coordinator.serial}_{key}"
 
 class SonnenSelectEntity(CoordinatorEntity[SonnenbatterieCoordinator], Entity):
     entity_description: SonnenbatterieSelectEntityDescription
@@ -124,8 +123,6 @@ class SonnenSelectEntity(CoordinatorEntity[SonnenbatterieCoordinator], Entity):
         super().__init__(coordinator)
         self.coordinator = coordinator
         self.entity_description = description
-        # {DOMAIN} is replaced by the correct platform by HA
-        self.entity_id = f"{DOMAIN}.{DOMAIN}_{self.coordinator.serial}_{self.entity_description.key}"
 
         self._attr_device_info = self.coordinator.device_info
         self._attr_translation_key = (
@@ -136,7 +133,7 @@ class SonnenSelectEntity(CoordinatorEntity[SonnenbatterieCoordinator], Entity):
 
     @property
     def unique_id(self) -> str:
-        return self.entity_id
+        return f"sonnenbatterie_{self.coordinator.serial}_{self.entity_description.key}"
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -156,7 +153,6 @@ class SonnenNumberEntity(CoordinatorEntity[SonnenbatterieCoordinator], Entity):
         self.coordinator = coordinator
         self.entity_description = description
 
-        self.entity_id = f"{DOMAIN}.{DOMAIN}_{self.coordinator.serial}_{self.entity_description.key}"
         self._attr_device_info = self.coordinator.device_info
         self._attr_translation_key = (
             tkey
@@ -166,7 +162,7 @@ class SonnenNumberEntity(CoordinatorEntity[SonnenbatterieCoordinator], Entity):
 
     @property
     def unique_id(self) -> str:
-        return self.entity_id
+        return f"sonnenbatterie_{self.coordinator.serial}_{self.entity_description.key}"
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -184,7 +180,6 @@ class SonnenButtonEntity(CoordinatorEntity[SonnenbatterieCoordinator], Entity):
         self.coordinator = coordinator
         self.entity_description = description
 
-        self.entity_id = f"{DOMAIN}.{DOMAIN}_{self.coordinator.serial}_{self.entity_description.key}"
         self._attr_device_info = self.coordinator.device_info
         self._attr_translation_key = (
             tkey
@@ -194,7 +189,7 @@ class SonnenButtonEntity(CoordinatorEntity[SonnenbatterieCoordinator], Entity):
 
     @property
     def unique_id(self) -> str:
-        return self.entity_id
+        return f"sonnenbatterie_{self.coordinator.serial}_{self.entity_description.key}"
 
 
 SELECT_ENTITIES = [

--- a/custom_components/sonnenbatterie/entities.py
+++ b/custom_components/sonnenbatterie/entities.py
@@ -112,7 +112,12 @@ class SonnenBaseEntity(CoordinatorEntity[SonnenbatterieCoordinator], Entity):
     @property
     def unique_id(self) -> str:
         key = self.entity_description.legacy_key or self.entity_description.key
-        return f"sonnenbatterie_{self.coordinator.serial}_{key}"
+        return f"{DOMAIN}_{self.coordinator.serial}_{key}"
+
+    @property
+    def suggested_object_id(self) -> str:
+        return f"{DOMAIN}_{self.coordinator.serial}_{self.entity_description.key}"
+
 
 class SonnenSelectEntity(CoordinatorEntity[SonnenbatterieCoordinator], Entity):
     entity_description: SonnenbatterieSelectEntityDescription
@@ -133,8 +138,11 @@ class SonnenSelectEntity(CoordinatorEntity[SonnenbatterieCoordinator], Entity):
 
     @property
     def unique_id(self) -> str:
-        return f"sonnenbatterie_{self.coordinator.serial}_{self.entity_description.key}"
+        return f"{DOMAIN}_{self.coordinator.serial}_{self.entity_description.key}"
 
+    @property
+    def suggested_object_id(self) -> str:
+        return f"{DOMAIN}_{self.coordinator.serial}_{self.entity_description.key}"
 
 @dataclass(frozen=True, kw_only=True)
 class SonnenbatterieNumberEntityDescription(NumberEntityDescription):
@@ -162,8 +170,11 @@ class SonnenNumberEntity(CoordinatorEntity[SonnenbatterieCoordinator], Entity):
 
     @property
     def unique_id(self) -> str:
-        return f"sonnenbatterie_{self.coordinator.serial}_{self.entity_description.key}"
+        return f"{DOMAIN}_{self.coordinator.serial}_{self.entity_description.key}"
 
+    @property
+    def suggested_object_id(self) -> str:
+        return f"{DOMAIN}_{self.coordinator.serial}_{self.entity_description.key}"
 
 @dataclass(frozen=True, kw_only=True)
 class SonnenbatterieButtonEntityDescription(ButtonEntityDescription):
@@ -189,8 +200,11 @@ class SonnenButtonEntity(CoordinatorEntity[SonnenbatterieCoordinator], Entity):
 
     @property
     def unique_id(self) -> str:
-        return f"sonnenbatterie_{self.coordinator.serial}_{self.entity_description.key}"
+        return f"{DOMAIN}_{self.coordinator.serial}_{self.entity_description.key}"
 
+    @property
+    def suggested_object_id(self) -> str:
+        return f"{DOMAIN}_{self.coordinator.serial}_{self.entity_description.key}"
 
 SELECT_ENTITIES = [
     SonnenbatterieSelectEntityDescription(

--- a/custom_components/sonnenbatterie/manifest.json
+++ b/custom_components/sonnenbatterie/manifest.json
@@ -8,5 +8,5 @@
     "iot_class": "local_polling",
     "issue_tracker": "https://github.com/weltmeyer/ha_sonnenbatterie/issues",
     "requirements": ["requests","sonnenbatterie>=0.7.1"],
-    "version": "2026.3.2"
+    "version": "2026.5.1"
 }

--- a/custom_components/sonnenbatterie/sensor.py
+++ b/custom_components/sonnenbatterie/sensor.py
@@ -81,7 +81,7 @@ class SonnenbatterieSensor(SonnenBaseEntity, SensorEntity, RestoreEntity):
         """Return a unique ID."""
         # legacy support / prevent breaking changes
         key = self.entity_description.legacy_key or self.entity_description.key
-        return f"sensor.sonnenbatterie_{self.coordinator.serial}_{key}"
+        return f"sonnenbatterie_{self.coordinator.serial}_{key}"
 
     @property
     def native_value(self) -> StateType:

--- a/custom_components/sonnenbatterie/sensor.py
+++ b/custom_components/sonnenbatterie/sensor.py
@@ -81,7 +81,7 @@ class SonnenbatterieSensor(SonnenBaseEntity, SensorEntity, RestoreEntity):
         """Return a unique ID."""
         # legacy support / prevent breaking changes
         key = self.entity_description.legacy_key or self.entity_description.key
-        return f"sonnenbatterie_{self.coordinator.serial}_{key}"
+        return f"sensor.sonnenbatterie_{self.coordinator.serial}_{key}"
 
     @property
     def native_value(self) -> StateType:


### PR DESCRIPTION
Removes incorrect explicit entity_id assignments that were using the integration domain for all entity types (sensor, select, number, button). Home Assistant automatically assigns the correct domain based on entity type.

Changes:
- Remove entity_id assignments from all entity base classes (SonnenBaseEntity, SonnenSelectEntity, SonnenNumberEntity, SonnenButtonEntity)
- Update unique_id to return domain-neutral format (sonnenbatterie_<serial>_<key>) instead of including domain prefix (sensor.sonnenbatterie_...)
- Let Home Assistant's entity registry auto-assign correct domain

This fixes the error: `Detected that custom integration 'sonnenbatterie' sets an entity ID with wrong domain: 'sonnenbatterie.sonnenbatterie_*'. Expected domain is 'sensor'`

Affected files:
- custom_components/sonnenbatterie/entities.py
- custom_components/sonnenbatterie/sensor.py