### PR TITLE
Fix KeyError when 'system'/'software' key absent in battery_system API response

### DIFF
--- a/custom_components/sonnenbatterie/coordinator.py
+++ b/custom_components/sonnenbatterie/coordinator.py
@@ -51,14 +51,14 @@ class SonnenbatterieCoordinator(DataUpdateCoordinator):
             model=system_info.get("ERP_ArticleName", "unknown"),
             name=f"{DOMAIN} {self.serial}",
             serial_number=f"{self.serial}",
-            sw_version=f"{system_data['software'].get('software_version', 'unknown')} ({system_data['software'].get('firmware_version', 'unknown')})",
-            hw_version=f"{system_data['system'].get('hardware_version', 'unknown'):.1f}",
+            sw_version=f"{system_data.get('software', {}).get('software_version', 'unknown')} ({system_data.get('software', {}).get('firmware_version', 'unknown')})",
+            hw_version=f"{system_data.get('system', {}).get('hardware_version', 'unknown')}",
         )
 
     def populate_battery_info(self):
         """ some manually calculated values """
         batt_module_capacity = int(
-            self.latestData["battery_system"]["battery_system"]["system"]["storage_capacity_per_module"]
+            self.latestData["battery_system"]["battery_system"].get("system", {}).get("storage_capacity_per_module", 0)
         )
         batt_module_count = int(self.latestData["battery_system"]["modules"])
 


### PR DESCRIPTION
## Problem

Some sonnenBatterie firmware versions do not include the `system` or `software` sub-key in the `battery_system` API response. This causes a `KeyError` crash in two places on every coordinator update cycle (every 30 s), flooding the Home Assistant log with errors:

```
KeyError: 'system'
  File "coordinator.py", line 55, in device_info
    hw_version=f"{system_data['system'].get('hardware_version', 'unknown'):.1f}",
```

```
KeyError: 'system'
  File "coordinator.py", line 61, in populate_battery_info
    self.latestData["battery_system"]["battery_system"]["system"]["storage_capacity_per_module"]
```

## Fix

Replace direct key access with `.get()` fallbacks so the integration degrades gracefully instead of raising an unhandled exception:

- `device_info`: `system_data['software']` → `system_data.get('software', {})`
- `device_info`: `system_data['system']` → `system_data.get('system', {})`
- `device_info`: removed `:.1f` format specifier on `hw_version` (value may be a string, not a float)
- `populate_battery_info`: `['system']['storage_capacity_per_module']` → `.get('system', {}).get('storage_capacity_per_module', 0)`

## Tested on

- sonnenBatterie integration v2026.3.2
- Home Assistant 2026.5.1