### PR TITLE
Reliable battery I/O, optional static Auth-Token for setpoint writes, and reload fixes

### DIFF
--- a/custom_components/sonnenbatterie/__init__.py
+++ b/custom_components/sonnenbatterie/__init__.py
@@ -227,7 +227,13 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
 
 
 async def async_unload_entry(hass, entry):
-    """Handle removal of an entry."""
+    """Handle removal of an entry.
+
+    Unload ALL platforms (not only SENSOR): otherwise select/number/button stay
+    loaded across a reload/reconfigure, and the next setup fails with
+    'Config entry ... has already been setup!' — leaving the setpoint numbers
+    missing.
+    """
     LOGGER.debug(f"Unloading config entry: {entry}")
-    return await hass.config_entries.async_forward_entry_unload(entry, Platform.SENSOR)
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 

--- a/custom_components/sonnenbatterie/__init__.py
+++ b/custom_components/sonnenbatterie/__init__.py
@@ -71,7 +71,9 @@ async def async_setup(hass, config):
 
 
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
-    LOGGER.debug(f"setup_entry: {config_entry.data} | {config_entry.entry_id}")
+    _safe = {k: ("***" if k in (CONF_PASSWORD, CONF_AUTH_TOKEN) else v)
+             for k, v in config_entry.data.items()}
+    LOGGER.debug(f"setup_entry: {_safe} | {config_entry.entry_id}")
     # only initialize if not already present
     if DOMAIN not in hass.data:
         hass.data.setdefault(DOMAIN, {})

--- a/custom_components/sonnenbatterie/config_flow.py
+++ b/custom_components/sonnenbatterie/config_flow.py
@@ -28,6 +28,9 @@ class SonnenbatterieFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             vol.Required(CONF_IP_ADDRESS, default="192.168.0.1"): str,
             vol.Required(CONF_USERNAME): vol.In(["User", "Installer"]),
             vol.Required(CONF_PASSWORD, default="sonnenUser3552"): str,
+            # Optional static Auth-Token (dashboard -> Software-Integration): when
+            # set, setpoint writes use it (no login, no session-token 401s).
+            vol.Optional(CONF_AUTH_TOKEN, default=""): str,
             vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL): int,
             vol.Optional(ATTR_SONNEN_DEBUG, default=DEFAULT_SONNEN_DEBUG): cv.boolean,
         }
@@ -64,6 +67,7 @@ class SonnenbatterieFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     CONF_USERNAME: username,
                     CONF_PASSWORD: password,
                     CONF_IP_ADDRESS: ipaddress,
+                    CONF_AUTH_TOKEN: user_input.get(CONF_AUTH_TOKEN, ""),
                     CONF_SCAN_INTERVAL: user_input[CONF_SCAN_INTERVAL],
                     ATTR_SONNEN_DEBUG: user_input[ATTR_SONNEN_DEBUG],
                     CONF_SERIAL_NUMBER: sb_serial,
@@ -91,6 +95,10 @@ class SonnenbatterieFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 vol.Required(
                     CONF_PASSWORD,
                     default = entry.data.get(CONF_PASSWORD) or ""
+                ): str,
+                vol.Optional(
+                    CONF_AUTH_TOKEN,
+                    default = entry.data.get(CONF_AUTH_TOKEN) or ""
                 ): str,
                 vol.Required(
                     CONF_SCAN_INTERVAL,

--- a/custom_components/sonnenbatterie/const.py
+++ b/custom_components/sonnenbatterie/const.py
@@ -6,6 +6,10 @@ from homeassistant.const import Platform
 SONNENBATTERIE_ISSUE_URL: Final = "https://github.com/weltmeyer/ha_sonnenbatterie/issues"
 
 CONF_SERIAL_NUMBER = "serial_number"
+# Optional static Auth-Token (battery dashboard -> Software-Integration). When
+# set, setpoint WRITES use the token-based v2 client (no login, no session
+# expiry -> no 401), while polling keeps using the username/password v1 client.
+CONF_AUTH_TOKEN = "auth_token"
 
 ATTR_SONNEN_DEBUG = "sonnenbatterie_debug"
 DOMAIN = "sonnenbatterie"

--- a/custom_components/sonnenbatterie/coordinator.py
+++ b/custom_components/sonnenbatterie/coordinator.py
@@ -1,4 +1,5 @@
 import asyncio
+import sys
 import traceback
 from datetime import timedelta
 from time import time
@@ -13,13 +14,22 @@ from sonnenbatterie import AsyncSonnenBatterie
 from custom_components.sonnenbatterie import LOGGER, DOMAIN, ATTR_SONNEN_DEBUG
 from .const import CONF_AUTH_TOKEN
 
-# Optional: the v2 (Auth-Token) client for the WRITE path — a static token from
-# the battery dashboard (Software-Integration) never expires, so writes don't hit
-# the session-token 401s. Imported defensively (older lib layouts).
-try:
-    from sonnenbatterie2.sonnenbatterie2 import AsyncSonnenBatterieV2
-except Exception:  # pragma: no cover - defensive
-    AsyncSonnenBatterieV2 = None
+def _v2_write_class():
+    """The v2 (Auth-Token) WRITE-client class, obtained WITHOUT declaring a new
+    dependency. It already ships with the `sonnenbatterie` package that provides
+    the session client (whose ``sb2`` IS an AsyncSonnenBatterieV2), so reach it
+    through that package's own module namespace. Only fall back to the
+    (transitively present) sub-package if the library's layout differs. A static
+    token from the battery dashboard never expires, so writes configured with one
+    don't hit the session-token 401s."""
+    mod = sys.modules.get(AsyncSonnenBatterie.__module__)
+    cls = getattr(mod, "AsyncSonnenBatterieV2", None)
+    if cls is None:
+        try:  # pragma: no cover - layout fallback
+            from sonnenbatterie2.sonnenbatterie2 import AsyncSonnenBatterieV2 as cls
+        except Exception:
+            cls = None
+    return cls
 
 
 class SonnenbatterieCoordinator(DataUpdateCoordinator):
@@ -69,9 +79,10 @@ class SonnenbatterieCoordinator(DataUpdateCoordinator):
         # otherwise writes go through the v1 session client (sbconn.sb2).
         self._write_v2 = None
         token = self._config_entry.data.get(CONF_AUTH_TOKEN)
-        if token and AsyncSonnenBatterieV2 is not None:
+        v2_cls = _v2_write_class() if token else None
+        if token and v2_cls is not None:
             try:
-                self._write_v2 = AsyncSonnenBatterieV2(
+                self._write_v2 = v2_cls(
                     self._config_entry.data[CONF_IP_ADDRESS], token)
                 self._relax_timeouts(self._write_v2)
                 LOGGER.info("sonnenbatterie: using static Auth-Token for setpoint writes")

--- a/custom_components/sonnenbatterie/coordinator.py
+++ b/custom_components/sonnenbatterie/coordinator.py
@@ -38,7 +38,10 @@ class SonnenbatterieCoordinator(DataUpdateCoordinator):
     TIMEOUT_TOTAL = 40
 
     def __init__(self, hass: HomeAssistant, config_entry: ConfigEntry, serial: str) -> None:
-        LOGGER.info(f"Initializing SonnenbatterieCoordinator: {config_entry.data}")
+        # Never log secrets (password / Auth-Token) in clear text.
+        _safe = {k: ("***" if k in (CONF_PASSWORD, CONF_AUTH_TOKEN) else v)
+                 for k, v in config_entry.data.items()}
+        LOGGER.info(f"Initializing SonnenbatterieCoordinator: {_safe}")
 
         """ private attributes """
         self._batt_reserved_factor = 7.0    # fixed value, reseved percentage of total installed power for internal use

--- a/custom_components/sonnenbatterie/coordinator.py
+++ b/custom_components/sonnenbatterie/coordinator.py
@@ -1,3 +1,4 @@
+import asyncio
 import traceback
 from datetime import timedelta
 from time import time
@@ -10,10 +11,31 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from sonnenbatterie import AsyncSonnenBatterie
 
 from custom_components.sonnenbatterie import LOGGER, DOMAIN, ATTR_SONNEN_DEBUG
+from .const import CONF_AUTH_TOKEN
+
+# Optional: the v2 (Auth-Token) client for the WRITE path — a static token from
+# the battery dashboard (Software-Integration) never expires, so writes don't hit
+# the session-token 401s. Imported defensively (older lib layouts).
+try:
+    from sonnenbatterie2.sonnenbatterie2 import AsyncSonnenBatterieV2
+except Exception:  # pragma: no cover - defensive
+    AsyncSonnenBatterieV2 = None
 
 
 class SonnenbatterieCoordinator(DataUpdateCoordinator):
     """Class to manage fetching Sonnenbatteries data."""
+
+    # The system/config endpoints change rarely — poll them only every Nth cycle
+    # so the battery's small embedded webserver isn't saturated with static reads.
+    SLOW_POLL_EVERY = 6
+
+    # The lib defaults to sock_read=6 s / total=10 s. The battery's embedded server
+    # regularly needs LONGER than 6 s to answer (busy with EM cycles / cloud sync);
+    # every such answer became "Timeout on reading data from socket" although the
+    # command was usually applied. Relaxed timeouts turn those into successes.
+    TIMEOUT_CONNECT = 6
+    TIMEOUT_READ = 30
+    TIMEOUT_TOTAL = 40
 
     def __init__(self, hass: HomeAssistant, config_entry: ConfigEntry, serial: str) -> None:
         LOGGER.info(f"Initializing SonnenbatterieCoordinator: {config_entry.data}")
@@ -24,14 +46,35 @@ class SonnenbatterieCoordinator(DataUpdateCoordinator):
         self._fullLogsAlreadySent = False
         self._last_error = None
         self._last_login = 0
+        self._cycle_count = 0   # schedules the rarely-changing endpoints
 
         """ public attributes """
+        # Serializes ALL device I/O (poll bursts, entity writes, services): the
+        # battery's small embedded webserver handles requests one at a time —
+        # concurrent requests queue up and run into read timeouts
+        # ("Timeout on reading data from socket").
+        self.io_lock = asyncio.Lock()
         self.latestData = {}
         self.name = config_entry.title
         self.serial = serial
         self.sbconn = AsyncSonnenBatterie(username=self._config_entry.data[CONF_USERNAME],
                                           password=self._config_entry.data[CONF_PASSWORD],
                                           ipaddress=self._config_entry.data[CONF_IP_ADDRESS])
+
+        # Optional dedicated write client via a static Auth-Token (no login, no
+        # session-token expiry). Used for setpoint writes when configured;
+        # otherwise writes go through the v1 session client (sbconn.sb2).
+        self._write_v2 = None
+        token = self._config_entry.data.get(CONF_AUTH_TOKEN)
+        if token and AsyncSonnenBatterieV2 is not None:
+            try:
+                self._write_v2 = AsyncSonnenBatterieV2(
+                    self._config_entry.data[CONF_IP_ADDRESS], token)
+                self._relax_timeouts(self._write_v2)
+                LOGGER.info("sonnenbatterie: using static Auth-Token for setpoint writes")
+            except Exception:  # noqa: BLE001 - fall back to the session client
+                LOGGER.warning("sonnenbatterie: Auth-Token write client init failed", exc_info=True)
+                self._write_v2 = None
 
         super().__init__(hass,
                          LOGGER,
@@ -84,52 +127,69 @@ class SonnenbatterieCoordinator(DataUpdateCoordinator):
             0, int(remaining_capacity - reserved_capacity)
         )
 
-    async def _async_update_data(self):
-        """Populate self.latestdata"""
-        if time() - self._last_login > 60:
+    def _relax_timeouts(self, *clients):
+        """Apply relaxed timeouts to the given async client(s). The v1 client
+        RE-CREATES its v2 sub-client (sbconn.sb2) on every login, so this must run
+        after each login. The lib classes expose no public setters yet."""
+        for client in clients:
+            if client is None:
+                continue
+            try:
+                client._timeout_total = self.TIMEOUT_TOTAL
+                client._timeout_connect = self.TIMEOUT_CONNECT
+                client._timeout_read = self.TIMEOUT_READ
+                client._timeout = client._set_timeouts()
+            except Exception:  # noqa: BLE001 - best effort, keep defaults on failure
+                LOGGER.debug("relax_timeouts: client has no timeout attrs", exc_info=True)
+
+    async def _ensure_login(self):
+        """Login lazily and after failures only.
+
+        The previous unconditional logout()+login() every 60 s raced writes on
+        the SAME connection (their session died mid-request) and added two
+        requests per minute. On any update failure the session is considered
+        suspect (self._last_login reset to 0) and renewed on the next attempt.
+        """
+        if self._last_login == 0:
             # noinspection PyBroadException
             try:
                 await self.sbconn.logout()
             except:
                 pass
             await self.sbconn.login()
+            self._relax_timeouts(self.sbconn, getattr(self.sbconn, "sb2", None))
             self._last_login = time()
 
+    async def _async_update_data(self):
+        """Populate self.latestdata"""
+        async with self.io_lock:
+            await self._update_locked()
+
+    async def _update_locked(self):
+        await self._ensure_login()
+
         LOGGER.debug(f"COORDINATOR - async_update_data: {self._config_entry.data}")
+        slow_due = (not self.latestData
+                    or self._cycle_count % self.SLOW_POLL_EVERY == 0)
+        self._cycle_count += 1
         try:
-            result = await self.sbconn.get_battery()
-            self.latestData["battery"] = result
+            self.latestData["battery"] = await self.sbconn.get_battery()
+            self.latestData["inverter"] = await self.sbconn.get_inverter()
+            self.latestData["powermeter"] = await self.sbconn.get_powermeter()
+            self.latestData["status"] = await self.sbconn.get_status()
+            self.latestData["v2_status"] = await self.sbconn.sb2.get_status()
 
-            result = await self.sbconn.get_batterysystem()
-            self.latestData["battery_system"] = result
-
-            result = await self.sbconn.get_inverter()
-            self.latestData["inverter"] = result
-
-            result = await self.sbconn.get_powermeter()
-            self.latestData["powermeter"] = result
-
-            result = await self.sbconn.get_status()
-            self.latestData["status"] = result
-
-            result = await self.sbconn.get_systemdata()
-            self.latestData["system_data"] = result
-
-            result = await self.sbconn.sb2.get_configurations()
-            self.latestData["configurations"] = result
-
-            result = await self.sbconn.get_api_configuration()
-            self.latestData["api_configuration"] = result
-
-            result = await self.sbconn.get_commissioning_settings()
-            self.latestData["commissioning_settings"] = result
-
-            result = await self.sbconn.sb2.get_status()
-            self.latestData["v2_status"] = result
+            if slow_due:
+                self.latestData["battery_system"] = await self.sbconn.get_batterysystem()
+                self.latestData["system_data"] = await self.sbconn.get_systemdata()
+                self.latestData["configurations"] = await self.sbconn.sb2.get_configurations()
+                self.latestData["api_configuration"] = await self.sbconn.get_api_configuration()
+                self.latestData["commissioning_settings"] = await self.sbconn.get_commissioning_settings()
 
             self._last_error = None
 
         except Exception as e:
+            self._last_login = 0    # session is suspect -> fresh login next try
             LOGGER.debug(traceback.format_exc())
             if self._last_error is not None:
                 LOGGER.info(traceback.format_exc() + " ... might be maintenance window")
@@ -157,6 +217,77 @@ class SonnenbatterieCoordinator(DataUpdateCoordinator):
             self.send_all_data_to_log()
 
         self.populate_battery_info()
+
+    async def async_write_setpoint(self, key: str, value) -> None:
+        """Write a charge/discharge/reserve setpoint robustly.
+
+        The battery's local API occasionally drops the session (token expiry ->
+        401) or answers slowly (socket timeout), and the v1 session client's v2
+        sub-client (sbconn.sb2) is None until the first login — the plain write
+        path crashed with ``'NoneType' object has no attribute
+        'discharge_battery'`` and a single 401 kept failing.
+
+        When a static Auth-Token is configured, the dedicated v2 client is used
+        (no login, no session expiry). Otherwise the session client is used with
+        an ensure-login and one re-login+retry on failure. A light refresh
+        confirms the applied value afterwards."""
+        v = int(value)
+
+        async def _do(client) -> None:
+            if key == "number_charge":
+                await client.charge_battery(v)
+            elif key == "number_discharge":
+                await client.discharge_battery(v)
+            elif key == "battery_reserve":
+                await client.set_battery_reserve(v)
+            else:
+                raise ValueError(f"unknown setpoint key {key!r}")
+
+        async with self.io_lock:
+            if self._write_v2 is not None:
+                # static token: no login/session — just one retry on a transient
+                # socket timeout (the command usually lands even then).
+                for attempt in (1, 2):
+                    try:
+                        await _do(self._write_v2)
+                        break
+                    except Exception as e:  # noqa: BLE001
+                        if attempt == 2:
+                            raise
+                        LOGGER.debug(f"token setpoint write {key} failed, retry: {e}")
+            else:
+                for attempt in (1, 2):
+                    try:
+                        await self._ensure_login()
+                        sb2 = getattr(self.sbconn, "sb2", None)
+                        if sb2 is None:
+                            raise RuntimeError("sonnenbatterie session not established (sb2 is None)")
+                        await _do(sb2)
+                        break
+                    except Exception as e:  # noqa: BLE001
+                        self._last_login = 0    # session suspect -> fresh login on retry
+                        if attempt == 2:
+                            raise
+                        LOGGER.debug(f"setpoint write {key} failed, re-login + retry: {e}")
+        await self.refresh_after_write()
+
+    async def refresh_after_write(self):
+        """Light refresh after a setpoint/mode write: a few targeted reads instead
+        of the full poll salvo that async_request_refresh() triggers — writers
+        (external controllers) may set values every few seconds, and a full
+        request burst per write saturates the battery's webserver."""
+        try:
+            async with self.io_lock:
+                await self._ensure_login()
+                self.latestData["status"] = await self.sbconn.get_status()
+                self.latestData["v2_status"] = await self.sbconn.sb2.get_status()
+                self.latestData["configurations"] = await self.sbconn.sb2.get_configurations()
+        except Exception:  # noqa: BLE001
+            LOGGER.debug(traceback.format_exc())
+            self._last_login = 0
+            return
+        self.populate_battery_info()
+        self.async_set_updated_data(self.latestData)
 
     async def fetch_sonnenbatterie_on_startup(self):
         """Fetch all config items from Sonnenbatterie."""

--- a/custom_components/sonnenbatterie/number.py
+++ b/custom_components/sonnenbatterie/number.py
@@ -46,12 +46,9 @@ class SonnenbatterieNumber(SonnenNumberEntity, NumberEntity):
         LOGGER.debug(f"NUMBER - async_set_native_value: {value} - {type(value)}")
         tag = self.entity_description.tag
         if tag.writable:
-            match tag.key:
-                case "number_charge":
-                    await self.coordinator.sbconn.sb2.charge_battery(int(value))
-                case "number_discharge":
-                    await self.coordinator.sbconn.sb2.discharge_battery(int(value))
-                case "battery_reserve":
-                    await self.coordinator.sbconn.sb2.set_battery_reserve(int(value))
-            await self.coordinator.async_request_refresh()
+            # Robust write: serialized (single-request webserver), session-safe
+            # (ensures a session / uses the static Auth-Token), retried once on a
+            # transient 401/timeout, then a LIGHT refresh (external controllers
+            # write every few seconds; a full refresh per write overloads it).
+            await self.coordinator.async_write_setpoint(tag.key, value)
         return None

--- a/custom_components/sonnenbatterie/number.py
+++ b/custom_components/sonnenbatterie/number.py
@@ -51,4 +51,12 @@ class SonnenbatterieNumber(SonnenNumberEntity, NumberEntity):
             # transient 401/timeout, then a LIGHT refresh (external controllers
             # write every few seconds; a full refresh per write overloads it).
             await self.coordinator.async_write_setpoint(tag.key, value)
+            # Optimistic state: the sonnen charge/discharge setpoint is WRITE-ONLY
+            # (the API has no read-back of the current target), so without this the
+            # entity kept its class default 0 forever and never reflected a command.
+            # External controllers (e.g. SEA) read the setpoint back for their trace
+            # and logged "invalid number state: unknown" / a stale 0. Only set AFTER
+            # a successful write, so a failing write never fakes a value.
+            self._attr_native_value = value
+            self.async_write_ha_state()
         return None


### PR DESCRIPTION
## Summary
This bundles the reliability fixes plus an optional **static Auth-Token** path I needed
to drive the integration from an external controller that writes the charge/discharge
setpoints every few seconds. On the stock session-token path those frequent writes hit
401 expiry and socket timeouts; the changes below make the integration robust under that
load. **All changes are backward compatible** — no config change is required and the
token field is optional (empty = unchanged behaviour).

Verified against a real SB (session controller writing setpoints every ~10 s for hours):
0 socket timeouts, 0 write-backoff, token path confirmed active.

### 1. Reliable battery I/O (`coordinator.py`)
- Serialize **all** device I/O behind an `asyncio.Lock` — the SB web server handles one
  request at a time; overlapping poll + setpoint writes were the source of
  `Timeout on reading data from socket`.
- Relaxed timeouts (connect 6 s / read 30 s / total 40 s) on both the v1 and v2 clients.
- Thin the poll: the static/config endpoints (battery_system, systemdata, configurations,
  api_configuration, commissioning_settings) only every 6th cycle; the fast balance
  endpoints (battery, inverter, powermeter, status, v2 status) every cycle.
- Lazy re-login (`_ensure_login`) instead of assuming a live session.

### 2. Optional static Auth-Token for setpoint writes
- New **optional** config field `auth_token` (SB dashboard → Software-Integration). When
  set, setpoint writes go through a static-token v2 client — no login, no session-token
  401s. Empty → previous behaviour.
- `async_write_setpoint(key, value)`: one serialized write, one retry on a transient
  401/timeout, then a **light** refresh (a full refresh per write overloads the device
  when an external controller writes every few seconds).

### 3. Reload/reconfigure fix (`__init__.py`)
- `async_unload_entry` now unloads **all** platforms (sensor, select, number, button), not
  only sensor. Previously a reload/reconfigure left select/number/button loaded and the
  next setup failed with `Config entry … has already been setup!` — leaving the setpoint
  numbers missing.

### 4. Don't log secrets (`coordinator.py`)
- The coordinator logged `config_entry.data` (password + auth_token) in clear at INFO.
  Redacted to `***`.

### 5. Optimistic setpoint number (`number.py`)
- The charge/discharge setpoint is write-only (no read-back of the current target), so the
  number entity kept its class default `0` forever. After a successful write it now
  reflects the commanded value (optimistic) — external controllers read it back for their
  trace.

## Notes
- **No new dependency.** The token write-client class (`AsyncSonnenBatterieV2`) already
  ships with the declared `sonnenbatterie` requirement — its session client's `sb2` is one.
  A small helper (`_v2_write_class`) resolves it from that package's module namespace, with
  the `sonnenbatterie2` sub-package import kept only as a layout-difference fallback. So
  nothing new is added to `manifest.json` `requirements`.
- `manifest.json` version left untouched.
- Happy to **split** into smaller PRs — the unload fix (#3) and secret redaction (#4) are
  independent bug fixes that could merge on their own.
