### PR TITLE
Add battery cell temperature sensors and /latestdata diagnostic binary sensors

### DIFF
--- a/custom_components/sonnenbatterie/binary_sensor.py
+++ b/custom_components/sonnenbatterie/binary_sensor.py
@@ -1,0 +1,46 @@
+from homeassistant.components.binary_sensor import BinarySensorEntity
+
+from . import CONF_COORDINATOR
+from .const import DOMAIN, LOGGER
+from .coordinator import SonnenbatterieCoordinator
+from .entities import SonnenBaseEntity
+
+from .binary_sensor_list import (
+    BINARY_SENSORS,
+    SonnenbatterieBinarySensorEntityDescription,
+)
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up the binary_sensor platform."""
+    LOGGER.debug(f"BINARY_SENSOR async_setup_entry - {config_entry.data}")
+    coordinator = hass.data[DOMAIN][config_entry.entry_id][CONF_COORDINATOR]
+
+    async_add_entities(
+        SonnenbatterieBinarySensor(coordinator=coordinator, entity_description=description)
+        for description in BINARY_SENSORS
+        if description.value_fn(coordinator) is not None
+    )
+
+    return True
+
+
+class SonnenbatterieBinarySensor(SonnenBaseEntity, BinarySensorEntity):
+    """Represent a SonnenBatterie binary sensor."""
+
+    def __init__(
+        self,
+        coordinator: SonnenbatterieCoordinator,
+        entity_description: SonnenbatterieBinarySensorEntityDescription,
+    ) -> None:
+        super().__init__(coordinator=coordinator, description=entity_description)
+
+    @property
+    def unique_id(self) -> str:
+        """Return a unique ID."""
+        return f"binary_sensor.sonnenbatterie_{self.coordinator.serial}_{self.entity_description.key}"
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return true if the fault/condition is present."""
+        return self.entity_description.value_fn(self.coordinator)

--- a/custom_components/sonnenbatterie/binary_sensor_list.py
+++ b/custom_components/sonnenbatterie/binary_sensor_list.py
@@ -1,0 +1,80 @@
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntityDescription,
+)
+from homeassistant.const import EntityCategory
+
+from custom_components.sonnenbatterie.coordinator import SonnenbatterieCoordinator
+
+
+@dataclass(frozen=True, kw_only=True)
+class SonnenbatterieBinarySensorEntityDescription(BinarySensorEntityDescription):
+    """Describes a Sonnenbatterie binary sensor entity."""
+    _attr_has_entity_name: bool = True
+    value_fn: Callable[[SonnenbatterieCoordinator], bool | None]
+
+
+BINARY_SENSORS: tuple[SonnenbatterieBinarySensorEntityDescription, ...] = (
+    ###
+    # fault flags, from /api/v2/latestdata (ic_status.DC Shutdown Reason)
+    SonnenbatterieBinarySensorEntityDescription(
+        key="latestdata_inverter_over_temperature",
+        icon="mdi:thermometer-alert",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda coordinator: coordinator.latestData.get("latestdata", {})
+        .get("ic_status", {})
+        .get("DC Shutdown Reason", {})
+        .get("Inverter Over Temperature"),
+        entity_registry_enabled_default=False,
+    ),
+    SonnenbatterieBinarySensorEntityDescription(
+        key="latestdata_critical_bms_alarm",
+        icon="mdi:alert-octagon-outline",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda coordinator: coordinator.latestData.get("latestdata", {})
+        .get("ic_status", {})
+        .get("DC Shutdown Reason", {})
+        .get("Critical BMS Alarm"),
+        entity_registry_enabled_default=False,
+    ),
+    SonnenbatterieBinarySensorEntityDescription(
+        key="latestdata_hw_shutdown",
+        icon="mdi:power-plug-off-outline",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda coordinator: coordinator.latestData.get("latestdata", {})
+        .get("ic_status", {})
+        .get("DC Shutdown Reason", {})
+        .get("HW_Shutdown"),
+        entity_registry_enabled_default=False,
+    ),
+    ###
+    # grid connection flags, from /api/v2/latestdata (ic_status.Droop mode status)
+    SonnenbatterieBinarySensorEntityDescription(
+        key="latestdata_grid_abnormal",
+        icon="mdi:transmission-tower-off",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda coordinator: coordinator.latestData.get("latestdata", {})
+        .get("ic_status", {})
+        .get("Droop mode status", {})
+        .get("Grid abnormal"),
+        entity_registry_enabled_default=False,
+    ),
+    SonnenbatterieBinarySensorEntityDescription(
+        key="latestdata_grid_detached",
+        icon="mdi:transmission-tower-off",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda coordinator: coordinator.latestData.get("latestdata", {})
+        .get("ic_status", {})
+        .get("Droop mode status", {})
+        .get("Grid detached"),
+        entity_registry_enabled_default=False,
+    ),
+)

--- a/custom_components/sonnenbatterie/const.py
+++ b/custom_components/sonnenbatterie/const.py
@@ -49,7 +49,7 @@ CONF_SERVICE_MODE = "mode"
 CONF_SERVICE_SCHEDULE = "schedule"
 CONF_SERVICE_VALUE = "value"
 
-PLATFORMS = [ Platform.SENSOR, Platform.SELECT, Platform.NUMBER, Platform.BUTTON ]
+PLATFORMS = [ Platform.SENSOR, Platform.BINARY_SENSOR, Platform.SELECT, Platform.NUMBER, Platform.BUTTON ]
 # PLATFORMS = [ Platform.SENSOR ]
 
 SB_OPERATING_MODES: Final = {

--- a/custom_components/sonnenbatterie/coordinator.py
+++ b/custom_components/sonnenbatterie/coordinator.py
@@ -198,6 +198,10 @@ class SonnenbatterieCoordinator(DataUpdateCoordinator):
                 self.latestData["system_data"] = await self.sbconn.get_systemdata()
                 self.latestData["configurations"] = await self.sbconn.sb2.get_configurations()
                 self.latestData["api_configuration"] = await self.sbconn.get_api_configuration()
+                # fault flags rarely change; the ~3.3KB payload is the largest of any
+                # endpoint we poll, so keep it on the slow cadence with the other
+                # diagnostic/config data rather than fetching it every cycle
+                self.latestData["latestdata"] = await self.sbconn.sb2.get_latest_data()
                 self.latestData["commissioning_settings"] = await self.sbconn.get_commissioning_settings()
 
             self._last_error = None

--- a/custom_components/sonnenbatterie/sensor_list.py
+++ b/custom_components/sonnenbatterie/sensor_list.py
@@ -393,6 +393,36 @@ SENSORS: tuple[SonnenbatterieSensorEntityDescription, ...] = (
         ),
     ),
     SonnenbatterieSensorEntityDescription(
+        key="battery_minimum_cell_temperature",
+        icon="mdi:thermometer-low",
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement="°C",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        suggested_display_precision=2,
+        value_fn=lambda coordinator: (
+            coordinator.latestData.get("battery", {})
+            .get("measurements", {})
+            .get("battery_status", {})
+            .get("minimumcelltemperature")
+        ),
+    ),
+    SonnenbatterieSensorEntityDescription(
+        key="battery_maximum_cell_temperature",
+        icon="mdi:thermometer-high",
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement="°C",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        suggested_display_precision=2,
+        value_fn=lambda coordinator: (
+            coordinator.latestData.get("battery", {})
+            .get("measurements", {})
+            .get("battery_status", {})
+            .get("maximumcelltemperature")
+        ),
+    ),
+    SonnenbatterieSensorEntityDescription(
         key="battery_installed_capacity_total",
         legacy_key="state_total_capacity_real",
         icon="mdi:battery-charging",

--- a/custom_components/sonnenbatterie/translations/de.json
+++ b/custom_components/sonnenbatterie/translations/de.json
@@ -132,6 +132,12 @@
             "battery_system_health": {
                 "name": "Akkuzustand"
             },
+            "battery_minimum_cell_temperature": {
+                "name": "Minimale Zellentemperatur"
+            },
+            "battery_maximum_cell_temperature": {
+                "name": "Maximale Zellentemperatur"
+            },
             "battery_installed_capacity_total": {
                 "name": "Akku installierte Gesamtkapazität"
             },

--- a/custom_components/sonnenbatterie/translations/de.json
+++ b/custom_components/sonnenbatterie/translations/de.json
@@ -198,6 +198,23 @@
             "battery_care": {
                 "name": "Batteriepflege aktiv"
             }
+        },
+        "binary_sensor": {
+            "latestdata_inverter_over_temperature": {
+                "name": "Wechselrichter Übertemperatur"
+            },
+            "latestdata_critical_bms_alarm": {
+                "name": "Kritischer BMS-Alarm"
+            },
+            "latestdata_hw_shutdown": {
+                "name": "Hardware-Abschaltung"
+            },
+            "latestdata_grid_abnormal": {
+                "name": "Netz anormal"
+            },
+            "latestdata_grid_detached": {
+                "name": "Netz getrennt"
+            }
         }
     },
     "services": {

--- a/custom_components/sonnenbatterie/translations/en.json
+++ b/custom_components/sonnenbatterie/translations/en.json
@@ -132,6 +132,12 @@
             "battery_system_health": {
                 "name": "Battery health"
             },
+            "battery_minimum_cell_temperature": {
+                "name": "Minimum cell temperature"
+            },
+            "battery_maximum_cell_temperature": {
+                "name": "Maximum cell temperature"
+            },
             "battery_installed_capacity_total": {
                 "name": "Battery total installed capacity"
             },

--- a/custom_components/sonnenbatterie/translations/en.json
+++ b/custom_components/sonnenbatterie/translations/en.json
@@ -198,6 +198,23 @@
             "battery_care": {
                 "name": "Battery care active"
             }
+        },
+        "binary_sensor": {
+            "latestdata_inverter_over_temperature": {
+                "name": "Inverter over temperature"
+            },
+            "latestdata_critical_bms_alarm": {
+                "name": "Critical BMS alarm"
+            },
+            "latestdata_hw_shutdown": {
+                "name": "Hardware shutdown"
+            },
+            "latestdata_grid_abnormal": {
+                "name": "Grid abnormal"
+            },
+            "latestdata_grid_detached": {
+                "name": "Grid detached"
+            }
         }
     },
     "services": {


### PR DESCRIPTION
Follow-up to #150 — thanks @RustyDust for the go-ahead.

## What's added

**Battery cell temperature** (`sensor_list.py`)
- Minimum/maximum cell temperature, sourced from `/battery` (`measurements.battery_status.{minimum,maximum}celltemperature`), which is already polled every cycle for existing sensors — no new API calls for this part. Enabled by default, alongside their siblings `battery_system_cycles`/`battery_system_health` in the same section.

**Diagnostic binary sensors from `/api/v2/latestdata`** (new `binary_sensor.py` / `binary_sensor_list.py`)
- Inverter over temperature, critical BMS alarm, hardware shutdown, grid abnormal, grid detached — fault/status flags that weren't exposed anywhere before.
- `/latestdata` isn't polled today; it's the largest single payload of any endpoint (~3.3KB). Added it to the existing slow cadence (every 6th cycle) alongside `configurations`/`battery_system`, since these flags rarely change — not fetched every cycle.
- All five disabled by default, matching the existing convention for advanced/diagnostic sensors in this integration.

Both English and German translations included for all seven new entities.

## Testing

Verified against a live sonnenBatterie eco 10 (firmware 1.31.11) via Home Assistant OS — deployed to `config/custom_components`, restarted, confirmed no errors in logs, confirmed correct live values (cell temps tracking real device readings; binary sensors correctly reporting "OK" via the `PROBLEM` device class with no faults present).

## CI

Ran hassfest and HACS validation against the branch on my fork before opening this — hassfest passes cleanly. HACS validation shows 2 unrelated failures (repo Issues/Topics not configured on my personal fork) that don't apply to this repo.